### PR TITLE
Temporarily updated Renderer interface

### DIFF
--- a/src/display/application.go
+++ b/src/display/application.go
@@ -121,7 +121,7 @@ func (a *application) RenderAndDraw() {
 	height := a.GetHeight()
 
 	// Render application
-	a.renderer.Render(a)
+	a.renderer.RenderWithRoot(a)
 
 	gl.Viewport(0, 0, int32(width), int32(height))
 	gl.Clear(gl.COLOR_BUFFER_BIT)

--- a/src/display/renderer.go
+++ b/src/display/renderer.go
@@ -4,7 +4,8 @@ import "log"
 
 type Renderer interface {
 	Surface
-	Render(d Displayable)
+	Render()
+	RenderWithRoot(d Displayable)
 }
 
 // Factory that operates over semantic sugar that we use to describe the
@@ -70,9 +71,16 @@ func (r *renderer) Reset() {
 	r.root = nil
 }
 
-func (r *renderer) Render(root Displayable) {
+func (r *renderer) RenderWithRoot(root Displayable) {
 	r.Reset()
 	r.Push(root)
+	r.renderHandler(r)
+	r.root.RenderChildren(r)
+	r.root.Render(r)
+}
+
+func (r *renderer) Render() {
+	r.Reset()
 	r.renderHandler(r)
 	r.root.RenderChildren(r)
 	r.root.Render(r)


### PR DESCRIPTION
...in order to segregate callers that have a reference to the root node and those that don't