### PR TITLE
Added xid generator in order to uniquely identify elements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ GOARCH=$(ARCH)
 GOLANG_VERSION=1.10
 GOLANG_SRC=tmp/golang
 
+# TODO(lbayes): Extract this duplicate garbage to a simpler config file
 GLFW_URL=github.com/go-gl/glfw/v3.2/glfw
 GLFW_PATH=vendor/src/$(GLFW_URL)
 GOGL_URL=github.com/go-gl/gl/v4.1-core/gl
@@ -27,6 +28,8 @@ GOMOBILE_URL=golang.org/x/mobile/cmd/gomobile
 GOMOBILE_PATH=vendor/src/$(GOMOBILE_URL)
 CAIRO_URL=github.com/golang-ui/cairo
 CAIRO_PATH=vendor/src/$(CAIRO_URL)
+XID_URL=github.com/rs/xid
+XID_PATH=vendor/src/$(XID_URL)
 
 GOLANG_PATH=lib/go-$(GOLANG_VERSION)
 GOLANG_BIN=$(GOLANG_PATH)/bin
@@ -63,7 +66,7 @@ clean:
 	rm -rf out
 	rm -rf .gocache
 
-libraries: $(GOGL_PATH) $(GLFW_PATH) $(GOMOBILE_PATH) $(CAIRO_PATH)
+libraries: $(GOGL_PATH) $(GLFW_PATH) $(GOMOBILE_PATH) $(CAIRO_PATH) $(XID_PATH)
 
 # Intall development dependencies (OS X and Linux only)
 dev-install: $(GOLANG_BINARY) libraries
@@ -106,4 +109,8 @@ $(GOMOBILE_PATH): vendor
 $(CAIRO_PATH): vendor
 	cd vendor/; $(GOLANG_BINARY) get -u -v $(CAIRO_URL)
 	touch $(CAIRO_PATH)
+
+$(XID_PATH): vendor
+	cd vendor/; $(GOLANG_BINARY) get -u -v $(XID_URL)
+	touch $(XID_PATH)
 

--- a/src/display/interfaces.go
+++ b/src/display/interfaces.go
@@ -5,6 +5,7 @@ type DisplayableFilter = func(Displayable) bool
 type Composable interface {
 	GetId() string
 	GetParent() Displayable
+	GetPath() string
 	AddChild(child Displayable) int
 	GetChildCount() int
 	GetChildAt(index int) Displayable

--- a/src/display/sprite.go
+++ b/src/display/sprite.go
@@ -1,6 +1,7 @@
 package display
 
 import (
+	"github.com/rs/xid"
 	"math"
 )
 
@@ -15,7 +16,12 @@ type Sprite struct {
 }
 
 func (s *Sprite) GetId() string {
-	return s.GetOptions().Id
+	opts := s.GetOptions()
+	if opts.Id == "" {
+		opts.Id = xid.New().String()
+	}
+
+	return opts.Id
 }
 
 func (s *Sprite) Layout(layout Layout) {
@@ -230,6 +236,17 @@ func (s *Sprite) GetFilteredChildren(filter DisplayableFilter) []Displayable {
 		}
 	}
 	return result
+}
+
+func (s *Sprite) GetPath() string {
+	parent := s.GetParent()
+	localPath := "/" + s.GetId()
+
+	if parent != nil {
+		return parent.GetPath() + localPath
+	}
+	return localPath
+
 }
 
 func (s *Sprite) GetParent() Displayable {

--- a/src/display/sprite_test.go
+++ b/src/display/sprite_test.go
@@ -8,6 +8,34 @@ import (
 
 func TestSprite(t *testing.T) {
 
+	t.Run("Generated Id", func(t *testing.T) {
+		root := NewSprite()
+		assert.Equal(len(root.GetId()), 20)
+	})
+
+	t.Run("Provided Id", func(t *testing.T) {
+		root := NewSpriteWithOpts(&Opts{Id: "root"})
+		assert.Equal(root.GetId(), "root")
+	})
+
+	t.Run("GetPath for root", func(t *testing.T) {
+		root := NewSpriteWithOpts(&Opts{Id: "root"})
+		assert.Equal(root.GetPath(), "/root")
+	})
+
+	t.Run("GetPath with depth", func(t *testing.T) {
+		root := NewSpriteWithOpts(&Opts{Id: "root"})
+		one := NewSpriteWithOpts(&Opts{Id: "one"})
+		two := NewSpriteWithOpts(&Opts{Id: "two"})
+		three := NewSpriteWithOpts(&Opts{Id: "three"})
+		root.AddChild(one)
+		one.AddChild(two)
+		two.AddChild(three)
+		assert.Equal(one.GetPath(), "/root/one")
+		assert.Equal(two.GetPath(), "/root/one/two")
+		assert.Equal(three.GetPath(), "/root/one/two/three")
+	})
+
 	t.Run("Padding", func(t *testing.T) {
 		t.Run("Applying Padding spreads to all four sides", func(t *testing.T) {
 			root := NewSpriteWithOpts(&Opts{Padding: 10})


### PR DESCRIPTION
This lib adds ~200k to the compiled binary size and uses some libraries features that may not be available or identical everywhere we want to run (they might, I just don't know for sure at this time).

Found the library online from this comparison:
https://blog.kowalczyk.info/article/JyRZ/generating-good-unique-ids-in-go.html

For these purposes, we don't need massive uniqueness guarantees and shorter ids would actually be more readable. There may also be performance and compatibility benefits to implementing something simple (and somewhat compliant) like what is outlined (for JavaScript) here:

http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/21963136#21963136
