### PR TITLE
Initial implementation of Builder

### DIFF
--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -1,0 +1,152 @@
+package builder
+
+type GlfwWindowHint int
+
+const (
+	AutoIconify = iota
+	Decorated
+	Floating
+	Focused
+	Iconified
+	Maximized
+	Resizable
+	Visible
+)
+
+/*
+// TODO(lbayes) Map local hints to glfw library hints
+const (
+	Focused     GlfwWindowHint = C.GLFW_FOCUSED      // Specifies whether the window will be given input focus when created. This hint is ignored for full screen and initially hidden windows.
+	Iconified   Hint = C.GLFW_ICONIFIED    // Specifies whether the window will be minimized.
+	Maximized   Hint = C.GLFW_MAXIMIZED    // Specifies whether the window is maximized.
+	Visible     Hint = C.GLFW_VISIBLE      // Specifies whether the window will be initially visible.
+	Resizable   Hint = C.GLFW_RESIZABLE    // Specifies whether the window will be resizable by the user.
+	Decorated   Hint = C.GLFW_DECORATED    // Specifies whether the window will have window decorations such as a border, a close widget, etc.
+	Floating    Hint = C.GLFW_FLOATING     // Specifies whether the window will be always-on-top.
+	AutoIconify Hint = C.GLFW_AUTO_ICONIFY // Specifies whether fullscreen windows automatically iconify (and restore the previous video mode) on focus loss.
+)
+
+*/
+
+const DefaultFrameRate = 60
+
+type SurfaceType int
+
+const (
+	CairoSurface = iota
+	ImageSurface
+	FakeSurface
+)
+
+type Option func(b *builder) error
+
+type windowHint struct {
+	name  GlfwWindowHint
+	value interface{}
+}
+
+type Builder interface {
+	GetSurfaceType() SurfaceType
+	GetFrameRate() int
+	GetWindowHints() []*windowHint
+	GetWindowHint(hintName GlfwWindowHint) interface{}
+}
+
+type builder struct {
+	surfaceType SurfaceType
+	frameRate   int
+	windowHints []*windowHint
+}
+
+func (b *builder) applyDefaults() {
+	b.frameRate = DefaultFrameRate
+	b.applyDefaultWindowHints()
+}
+
+func (b *builder) applyDefaultWindowHints() {
+	b.windowHints = []*windowHint{
+		&windowHint{name: AutoIconify, value: false},
+		&windowHint{name: Decorated, value: false},
+		&windowHint{name: Floating, value: true},
+		&windowHint{name: Focused, value: true},
+		&windowHint{name: Iconified, value: false},
+		&windowHint{name: Maximized, value: false},
+		&windowHint{name: Resizable, value: true},
+		&windowHint{name: Visible, value: true},
+	}
+}
+
+func (b *builder) removeWindowHint(hintName GlfwWindowHint) {
+	hints := b.windowHints
+	for i := 0; i < len(hints); i++ {
+		if hints[i].name == hintName {
+			b.windowHints = append(hints[:i], hints[i+1:]...)
+			return
+		}
+	}
+}
+
+func (b *builder) GetSurfaceType() SurfaceType {
+	return b.surfaceType
+}
+
+func (b *builder) GetFrameRate() int {
+	return b.frameRate
+}
+
+func (b *builder) GetWindowHint(hintName GlfwWindowHint) interface{} {
+	for _, hint := range b.windowHints {
+		if hint.name == hintName {
+			return hint.value
+		}
+	}
+	return nil
+}
+
+func (b *builder) GetWindowHints() []*windowHint {
+	return b.windowHints
+}
+
+func NewBuilder(args ...Option) (Builder, error) {
+	b := &builder{}
+	b.applyDefaults()
+
+	for _, arg := range args {
+		err := arg(b)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return b, nil
+}
+
+// Surface Option for Builder
+func Surface(surfaceType SurfaceType) Option {
+	return func(b *builder) error {
+		b.surfaceType = surfaceType
+		return nil
+	}
+}
+
+func FrameRate(fps int) Option {
+	return func(b *builder) error {
+		b.frameRate = fps
+		return nil
+	}
+}
+
+func WindowHint(hintName GlfwWindowHint, value interface{}) Option {
+	wHint := &windowHint{
+		name:  hintName,
+		value: value,
+	}
+
+	return func(b *builder) error {
+		// First remove existing hint by same name if found
+		b.removeWindowHint(hintName)
+
+		b.windowHints = append(b.windowHints, wHint)
+		return nil
+	}
+}

--- a/src/builder/builder.go
+++ b/src/builder/builder.go
@@ -1,23 +1,26 @@
 package builder
 
+import "display"
+
 type Builder interface {
-	GetSurfaceType() SurfaceType
+	Build(factory ComponentFactory) (root display.Displayable, err error)
 	GetFrameRate() int
-	GetWindowHints() []*windowHint
-	GetWindowHint(hintName GlfwWindowHint) interface{}
-	GetWidth() int
 	GetHeight() int
 	GetSize() (width int, height int)
+	GetSurfaceType() SurfaceTypeName
 	GetTitle() string
+	GetWidth() int
+	GetWindowHint(hintName GlfwWindowHint) interface{}
+	GetWindowHints() []*windowHint
 }
 
 type builder struct {
-	surfaceType SurfaceType
-	frameRate   int
-	windowHints []*windowHint
-	width       int
-	height      int
-	title       string
+	surfaceTypeName SurfaceTypeName
+	frameRate       int
+	windowHints     []*windowHint
+	width           int
+	height          int
+	title           string
 }
 
 func (b *builder) applyDefaults() {
@@ -51,8 +54,13 @@ func (b *builder) removeWindowHint(hintName GlfwWindowHint) {
 	}
 }
 
-func (b *builder) GetSurfaceType() SurfaceType {
-	return b.surfaceType
+func (b *builder) Build(factory ComponentFactory) (root display.Displayable, err error) {
+
+	return nil, nil
+}
+
+func (b *builder) GetSurfaceType() SurfaceTypeName {
+	return b.surfaceTypeName
 }
 
 func (b *builder) GetFrameRate() int {

--- a/src/builder/builder_options.go
+++ b/src/builder/builder_options.go
@@ -1,8 +1,6 @@
 package builder
 
-import "display"
-
-type ComponentFactory func(s display.Surface)
+type ComponentFactory func(b Builder)
 
 type GlfwWindowHint int
 

--- a/src/builder/builder_options.go
+++ b/src/builder/builder_options.go
@@ -1,5 +1,9 @@
 package builder
 
+import "display"
+
+type ComponentFactory func(s display.Surface)
+
 type GlfwWindowHint int
 
 const (
@@ -33,7 +37,7 @@ const DefaultWidth = 1024
 const DefaultHeight = 768
 const DefaultTitle = "Default Title"
 
-type SurfaceType int
+type SurfaceTypeName int
 
 const (
 	CairoSurface = iota
@@ -49,9 +53,9 @@ type windowHint struct {
 }
 
 // Surface Option for Builder
-func Surface(surfaceType SurfaceType) Option {
+func SurfaceType(surfaceType SurfaceTypeName) Option {
 	return func(b *builder) error {
-		b.surfaceType = surfaceType
+		b.surfaceTypeName = surfaceType
 		return nil
 	}
 }

--- a/src/builder/builder_options.go
+++ b/src/builder/builder_options.go
@@ -1,0 +1,94 @@
+package builder
+
+type GlfwWindowHint int
+
+const (
+	AutoIconify = iota
+	Decorated
+	Floating
+	Focused
+	Iconified
+	Maximized
+	Resizable
+	Visible
+)
+
+/*
+// TODO(lbayes) Map local hints to glfw library hints
+const (
+	Focused     GlfwWindowHint = C.GLFW_FOCUSED      // Specifies whether the window will be given input focus when created. This hint is ignored for full screen and initially hidden windows.
+	Iconified   Hint = C.GLFW_ICONIFIED    // Specifies whether the window will be minimized.
+	Maximized   Hint = C.GLFW_MAXIMIZED    // Specifies whether the window is maximized.
+	Visible     Hint = C.GLFW_VISIBLE      // Specifies whether the window will be initially visible.
+	Resizable   Hint = C.GLFW_RESIZABLE    // Specifies whether the window will be resizable by the user.
+	Decorated   Hint = C.GLFW_DECORATED    // Specifies whether the window will have window decorations such as a border, a close widget, etc.
+	Floating    Hint = C.GLFW_FLOATING     // Specifies whether the window will be always-on-top.
+	AutoIconify Hint = C.GLFW_AUTO_ICONIFY // Specifies whether fullscreen windows automatically iconify (and restore the previous video mode) on focus loss.
+)
+
+*/
+
+const DefaultFrameRate = 60
+const DefaultWidth = 1024
+const DefaultHeight = 768
+const DefaultTitle = "Default Title"
+
+type SurfaceType int
+
+const (
+	CairoSurface = iota
+	ImageSurface
+	FakeSurface
+)
+
+type Option func(b *builder) error
+
+type windowHint struct {
+	name  GlfwWindowHint
+	value interface{}
+}
+
+// Surface Option for Builder
+func Surface(surfaceType SurfaceType) Option {
+	return func(b *builder) error {
+		b.surfaceType = surfaceType
+		return nil
+	}
+}
+
+func FrameRate(fps int) Option {
+	return func(b *builder) error {
+		b.frameRate = fps
+		return nil
+	}
+}
+
+func Size(width int, height int) Option {
+	return func(b *builder) error {
+		b.width = width
+		b.height = height
+		return nil
+	}
+}
+
+func WindowHint(hintName GlfwWindowHint, value interface{}) Option {
+	wHint := &windowHint{
+		name:  hintName,
+		value: value,
+	}
+
+	return func(b *builder) error {
+		// First remove existing hint by same name if found
+		b.removeWindowHint(hintName)
+
+		b.windowHints = append(b.windowHints, wHint)
+		return nil
+	}
+}
+
+func Title(title string) Option {
+	return func(b *builder) error {
+		b.title = title
+		return nil
+	}
+}

--- a/src/builder/builder_test.go
+++ b/src/builder/builder_test.go
@@ -1,6 +1,8 @@
 package builder
 
 import (
+	"assert"
+	"display"
 	"testing"
 )
 
@@ -46,7 +48,7 @@ func TestBuilder(t *testing.T) {
 	})
 
 	t.Run("With multiple options", func(t *testing.T) {
-		builder, _ := NewBuilder(Surface(ImageSurface), FrameRate(24))
+		builder, _ := NewBuilder(SurfaceType(ImageSurface), FrameRate(24))
 
 		if builder.GetSurfaceType() != ImageSurface {
 			t.Error("Expected FakeSurface")
@@ -56,8 +58,8 @@ func TestBuilder(t *testing.T) {
 		}
 	})
 
-	t.Run("Accepts SurfaceType", func(t *testing.T) {
-		builder, _ := NewBuilder(Surface(FakeSurface))
+	t.Run("Accepts SurfaceTypeName", func(t *testing.T) {
+		builder, _ := NewBuilder(SurfaceType(FakeSurface))
 		if builder.GetSurfaceType() != FakeSurface {
 			t.Error("Expected FakeSurface")
 		}
@@ -89,5 +91,29 @@ func TestBuilder(t *testing.T) {
 		if builder.GetWindowHint(Resizable) != false {
 			t.Errorf("Expected WindowHint to be resizable")
 		}
+	})
+
+	t.Run("Builds provided elements", func(t *testing.T) {
+		t.Skip()
+		builder, _ := NewBuilder()
+		box, _ := builder.Build(func(s display.Surface) {
+			display.Box(s)
+		})
+		if box == nil {
+			t.Error("Expected root displayable to be returned")
+		}
+	})
+
+	t.Run("Returns error when more than one root node is provided", func(t *testing.T) {
+		t.Skip()
+		builder, _ := NewBuilder()
+		box, err := builder.Build(func(s display.Surface) {
+			display.Box(s)
+			display.Box(s)
+		})
+		if box != nil {
+			t.Errorf("Expected nil result with error state")
+		}
+		assert.ErrorMatch("ssdfsdf", err)
 	})
 }

--- a/src/builder/builder_test.go
+++ b/src/builder/builder_test.go
@@ -1,0 +1,72 @@
+package builder
+
+import (
+	"testing"
+)
+
+func TestBuilder(t *testing.T) {
+	t.Run("Instantiated", func(t *testing.T) {
+		builder, _ := NewBuilder()
+		if builder == nil {
+			t.Error("Expected builder instance")
+		}
+	})
+
+	t.Run("With defaults", func(t *testing.T) {
+		builder, _ := NewBuilder()
+		if builder.GetFrameRate() != DefaultFrameRate {
+			t.Errorf("Unexpected default frame rate: %d", builder.GetFrameRate())
+		}
+
+		if builder.GetWindowHint(Resizable) != true {
+			t.Errorf("Unexpected default window to be Resizable")
+		}
+		if builder.GetWindowHint(Focused) != true {
+			t.Errorf("Unexpected default window to be Focused")
+		}
+		if builder.GetWindowHint(Visible) != true {
+			t.Errorf("Unexpected default window to be Visible")
+		}
+		if builder.GetWindowHint(Floating) != true {
+			t.Errorf("Unexpected default window to be Floating")
+		}
+		if builder.GetWindowHint(Decorated) != false {
+			t.Errorf("Unexpected default window to not be Decorated")
+		}
+	})
+
+	t.Run("With multiple options", func(t *testing.T) {
+		builder, _ := NewBuilder(Surface(ImageSurface), FrameRate(24))
+
+		if builder.GetSurfaceType() != ImageSurface {
+			t.Error("Expected FakeSurface")
+		}
+		if builder.GetFrameRate() != 24 {
+			t.Errorf("Expected configured FrameRate, but found %d", builder.GetFrameRate())
+		}
+	})
+
+	t.Run("Accepts SurfaceType", func(t *testing.T) {
+		builder, _ := NewBuilder(Surface(FakeSurface))
+		if builder.GetSurfaceType() != FakeSurface {
+			t.Error("Expected FakeSurface")
+		}
+	})
+
+	t.Run("Accepts FrameRate", func(t *testing.T) {
+		builder, _ := NewBuilder(FrameRate(12))
+		if builder.GetFrameRate() != 12 {
+			t.Errorf("Expected configured FrameRate, but found %d", builder.GetFrameRate())
+		}
+	})
+
+	t.Run("Accepts WindowHints", func(t *testing.T) {
+		builder, _ := NewBuilder(WindowHint(Floating, true), WindowHint(Resizable, false))
+		if builder.GetWindowHint(Floating) != true {
+			t.Errorf("Expected WindowHint to be floating")
+		}
+		if builder.GetWindowHint(Resizable) != false {
+			t.Errorf("Expected WindowHint to be resizable")
+		}
+	})
+}

--- a/src/builder/builder_test.go
+++ b/src/builder/builder_test.go
@@ -18,6 +18,13 @@ func TestBuilder(t *testing.T) {
 			t.Errorf("Unexpected default frame rate: %d", builder.GetFrameRate())
 		}
 
+		if builder.GetWidth() != DefaultWidth {
+			t.Errorf("Unexpected default size %d", builder.GetWidth())
+		}
+		if builder.GetHeight() != DefaultHeight {
+			t.Errorf("Unexpected default size %d", builder.GetHeight())
+		}
+
 		if builder.GetWindowHint(Resizable) != true {
 			t.Errorf("Unexpected default window to be Resizable")
 		}
@@ -32,6 +39,9 @@ func TestBuilder(t *testing.T) {
 		}
 		if builder.GetWindowHint(Decorated) != false {
 			t.Errorf("Unexpected default window to not be Decorated")
+		}
+		if builder.GetTitle() != "Default Title" {
+			t.Errorf("Unexpected default title %s", builder.GetTitle())
 		}
 	})
 
@@ -57,6 +67,17 @@ func TestBuilder(t *testing.T) {
 		builder, _ := NewBuilder(FrameRate(12))
 		if builder.GetFrameRate() != 12 {
 			t.Errorf("Expected configured FrameRate, but found %d", builder.GetFrameRate())
+		}
+	})
+
+	t.Run("Accepts Size", func(t *testing.T) {
+		builder, _ := NewBuilder(Size(800, 600))
+		width, height := builder.GetSize()
+		if width != 800 {
+			t.Errorf("Expected configured Width, but found %d", width)
+		}
+		if height != 600 {
+			t.Errorf("Expected configured Height, but found %d", height)
 		}
 	})
 

--- a/src/builder/builder_test.go
+++ b/src/builder/builder_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 )
 
+func FakeSprite(b Builder, opts *display.Opts) *display.Sprite {
+	sprite := display.NewSpriteWithOpts(opts)
+	b.Push(sprite)
+	return sprite
+}
+
 func TestBuilder(t *testing.T) {
 	t.Run("Instantiated", func(t *testing.T) {
 		builder, _ := NewBuilder()
@@ -93,27 +99,35 @@ func TestBuilder(t *testing.T) {
 		}
 	})
 
-	t.Run("Builds provided elements", func(t *testing.T) {
-		t.Skip()
-		builder, _ := NewBuilder()
-		box, _ := builder.Build(func(s display.Surface) {
-			display.Box(s)
-		})
-		if box == nil {
-			t.Error("Expected root displayable to be returned")
-		}
-	})
-
 	t.Run("Returns error when more than one root node is provided", func(t *testing.T) {
-		t.Skip()
 		builder, _ := NewBuilder()
-		box, err := builder.Build(func(s display.Surface) {
-			display.Box(s)
-			display.Box(s)
+		box, err := builder.Build(func(b Builder) {
+			FakeSprite(b, &display.Opts{})
+			FakeSprite(b, &display.Opts{})
 		})
+		if err == nil {
+			t.Error("Expected an error from builder")
+		}
+		assert.ErrorMatch("single root node", err)
+
 		if box != nil {
 			t.Errorf("Expected nil result with error state")
 		}
-		assert.ErrorMatch("ssdfsdf", err)
+	})
+
+	t.Run("Builds provided elements", func(t *testing.T) {
+		builder, _ := NewBuilder()
+		sprite, _ := builder.Build(func(b Builder) {
+			FakeSprite(b, &display.Opts{Width: 200, Height: 100})
+		})
+		if sprite == nil {
+			t.Error("Expected root displayable to be returned")
+		}
+		if sprite.GetWidth() != 200.0 {
+			t.Errorf("Expected sprite width to be set but was %f", sprite.GetWidth())
+		}
+		if sprite.GetHeight() != 100 {
+			t.Errorf("Expected sprite height to be set but was %f", sprite.GetHeight())
+		}
 	})
 }

--- a/src/display/builder.go
+++ b/src/display/builder.go
@@ -1,5 +1,118 @@
 package display
 
+// import "errors"
+
+type SurfaceType int
+
+const (
+	CairoSurfaceType = iota
+	ImageSurfaceType
+	FakeSurfaceType
+)
+
+type GlfwWindowHint int
+
+const (
+	AutoIconify = iota
+	Decorated
+	Floating
+	Focused
+	Iconified
+	Maximized
+	Resizable
+	Visible
+)
+
+/*
+// TODO(lbayes) Map local hints to glfw library hints
+const (
+	Focused     GlfwWindowHint = C.GLFW_FOCUSED      // Specifies whether the window will be given input focus when created. This hint is ignored for full screen and initially hidden windows.
+	Iconified   Hint = C.GLFW_ICONIFIED    // Specifies whether the window will be minimized.
+	Maximized   Hint = C.GLFW_MAXIMIZED    // Specifies whether the window is maximized.
+	Visible     Hint = C.GLFW_VISIBLE      // Specifies whether the window will be initially visible.
+	Resizable   Hint = C.GLFW_RESIZABLE    // Specifies whether the window will be resizable by the user.
+	Decorated   Hint = C.GLFW_DECORATED    // Specifies whether the window will have window decorations such as a border, a close widget, etc.
+	Floating    Hint = C.GLFW_FLOATING     // Specifies whether the window will be always-on-top.
+	AutoIconify Hint = C.GLFW_AUTO_ICONIFY // Specifies whether fullscreen windows automatically iconify (and restore the previous video mode) on focus loss.
+)
+
+*/
+
+type Builder2 interface {
+	// Provide a named surface type (CairoSurface, ImageSurface, FakeSurface)
+	WithSurfaceType(t SurfaceType) Builder2
+	// Provide a concrete surface instance.
+	WithSurface(t Surface) Builder2
+	// Provide the desired frame rate (in frames per second)
+	WithFrameRate(fps int) Builder2
+	// Provide zero or more Window Hints to Glfw.
+	WithHint(name GlfwWindowHint, value interface{}) Builder2
+	// Provide width and height to the native window.
+	WithSize(width int, height int) Builder2
+	// Provide title to the native window.
+	WithTitle(title string) Builder2
+	// Execute the configured builder and receive a surface that can be used to
+	//draw visual components.
+	Build(handler func(s Surface)) error
+
+	GetNativeWindowSize() (width int, height int)
+	PollEvents() []interface{}
+}
+
+type builder2 struct {
+	windowHints map[GlfwWindowHint]interface{}
+}
+
+// Provide a named surface type (CairoSurface, ImageSurface, FakeSurface)
+func (b *builder2) WithSurfaceType(t SurfaceType) Builder2 {
+	return b
+}
+
+// Provide a concrete surface instance.
+func (b *builder2) WithSurface(t Surface) Builder2 {
+	return b
+}
+
+// Provide the desired frame rate (in frames per second)
+func (b *builder2) WithFrameRate(fps int) Builder2 {
+	return b
+}
+
+// Provide zero or more Window Hints to Glfw.
+func (b *builder2) WithHint(name GlfwWindowHint, value interface{}) Builder2 {
+	return b
+}
+
+// Provide width and height to the native window.
+func (b *builder2) WithSize(width int, height int) Builder2 {
+	return b
+}
+
+// Provide title to the native window.
+func (b *builder2) WithTitle(title string) Builder2 {
+	return b
+}
+
+// Execute the configured builder and receive a surface that can be used to
+//draw visual components.
+func (b *builder2) Build(handler func(s Surface)) error {
+	return nil
+}
+
+func (b *builder2) GetNativeWindowSize() (width int, height int) {
+	return 0, 0
+}
+
+func (b *builder2) PollEvents() []interface{} {
+	return nil
+}
+
+func NewBuilder2() Builder2 {
+	return &builder2{}
+}
+
+//----------------------------------------------------------------------
+
 type Builder interface {
 	Build()
 	BuildWithRoot(d Displayable)

--- a/src/display/builder_test.go
+++ b/src/display/builder_test.go
@@ -1,13 +1,32 @@
 package display
 
 import (
+	"assert"
 	"testing"
 )
 
-func TestFactory(t *testing.T) {
+func TestBuilder(t *testing.T) {
 	surface := &FakeSurface{}
 
 	t.Run("CreateBuilder", func(t *testing.T) {
+		builder := NewBuilder2()
+		builder.WithHint(Floating, true)
+		builder.WithHint(Resizable, true)
+		builder.WithHint(Visible, true)
+		builder.WithSurfaceType(CairoSurfaceType)
+		builder.WithFrameRate(12)
+		builder.WithSize(640, 480)
+		builder.WithTitle("Hello World")
+
+		err := builder.Build(func(s Surface) {
+			// components here
+		})
+
+		assert.Nil(err)
+		assert.NotNil(builder)
+	})
+
+	t.Run("CreateLegacyBuilder", func(t *testing.T) {
 		builder := CreateBuilder(surface, func(s Surface) {
 			Box(s, &Opts{Width: 100, Height: 100, StyleName: "abcd"})
 		})


### PR DESCRIPTION
Initial build, but not yet integrated. Will replace the display.Builder/Renderer that was all messy and confusing.

This builder decouples the construction of components from their display.

This builder interface will be used by component factory functions, but otherwise will not be referenced from components. A concrete GLFW, Image builder will enable component rendering.

Component implementation will now involve a simpler interface and rendering and building are decoupled.