### PR TITLE
Fixed drawing offset by introducing SurfaceDelegate with offset values

### DIFF
--- a/src/display/cairo_surface.go
+++ b/src/display/cairo_surface.go
@@ -1,9 +1,7 @@
 package display
 
 import (
-	"fmt"
 	"github.com/golang-ui/cairo"
-	"math"
 )
 
 type cairoSurfaceAdapter struct {
@@ -31,7 +29,6 @@ func (c *cairoSurfaceAdapter) Arc(xc float64, yc float64, radius float64, angle1
 }
 
 func (c *cairoSurfaceAdapter) DrawRectangle(x float64, y float64, width float64, height float64) {
-	fmt.Println("DRAW RECT:", x, y, width, height)
 	cairo.MakeRectangle(c.context, x, y, width, height)
 }
 
@@ -43,35 +40,8 @@ func (c *cairoSurfaceAdapter) FillPreserve() {
 	cairo.FillPreserve(c.context)
 }
 
-func (c *cairoSurfaceAdapter) getYOffsetFor(d Displayable) float64 {
-	current := d
-	offset := 0.0
-	for current != nil {
-		offset += math.Max(0, current.GetY())
-		current = d.GetParent()
-	}
-	return offset
-}
-
-func (s *cairoSurfaceAdapter) getXOffsetFor(d Displayable) float64 {
-	current := d
-	offset := 0.0
-	for current != nil {
-		offset += math.Max(0, current.GetX())
-		current = d.GetParent()
-	}
-	return offset
-}
-
 func (c *cairoSurfaceAdapter) GetOffsetSurfaceFor(d Displayable) Surface {
-	fmt.Println("Cairo.GetOffSurfaceFor:", d.GetId())
-	x := c.getXOffsetFor(d)
-	y := c.getYOffsetFor(d)
-	return &SurfaceDelegate{
-		delegateTo: c,
-		offsetX:    x,
-		offsetY:    y,
-	}
+	return NewSurfaceDelegateFor(d, c)
 }
 
 func NewCairoSurfaceAdapter(cairo *cairo.Cairo) Surface {

--- a/src/display/cairo_surface.go
+++ b/src/display/cairo_surface.go
@@ -1,7 +1,7 @@
 package display
 
 import (
-	"errors"
+	"fmt"
 	"github.com/golang-ui/cairo"
 )
 
@@ -30,6 +30,7 @@ func (c *cairoSurface) Arc(xc float64, yc float64, radius float64, angle1 float6
 }
 
 func (c *cairoSurface) DrawRectangle(x float64, y float64, width float64, height float64) {
+	fmt.Println("DRAW RECT:", x, y, width, height)
 	cairo.MakeRectangle(c.context, x, y, width, height)
 }
 
@@ -41,13 +42,35 @@ func (c *cairoSurface) FillPreserve() {
 	cairo.FillPreserve(c.context)
 }
 
-func (c *cairoSurface) Push(d Displayable) error {
-	return errors.New("Unsupported method")
+func (c *cairoSurface) getYOffsetFor(d Displayable) float64 {
+	current := d
+	offset := 0.0
+	for current != nil {
+		offset += current.GetY()
+		current = d.GetParent()
+	}
+	return offset
 }
 
-func (c *cairoSurface) GetRoot() Displayable {
-	// Not sure how to throw when error is not part of the interface. :-(
-	panic("Unsupported method")
+func (s *cairoSurface) getXOffsetFor(d Displayable) float64 {
+	current := d
+	offset := 0.0
+	for current != nil {
+		offset += current.GetX()
+		current = d.GetParent()
+	}
+	return offset
+}
+
+func (c *cairoSurface) GetOffsetSurfaceFor(d Displayable) Surface {
+	fmt.Println("CairoGetOffSurfaceFor!")
+	x := c.getXOffsetFor(d)
+	y := c.getYOffsetFor(d)
+	return &SurfaceDelegate{
+		delegateTo: c,
+		offsetX:    x,
+		offsetY:    y,
+	}
 }
 
 func NewCairoSurface(cairo *cairo.Cairo) Surface {

--- a/src/display/cairo_surface.go
+++ b/src/display/cairo_surface.go
@@ -3,67 +3,68 @@ package display
 import (
 	"fmt"
 	"github.com/golang-ui/cairo"
+	"math"
 )
 
-type cairoSurface struct {
+type cairoSurfaceAdapter struct {
 	context *cairo.Cairo
 }
 
-func (c *cairoSurface) MoveTo(x float64, y float64) {
+func (c *cairoSurfaceAdapter) MoveTo(x float64, y float64) {
 	cairo.MoveTo(c.context, x, y)
 }
 
-func (c *cairoSurface) SetRgba(r, g, b, a float64) {
+func (c *cairoSurfaceAdapter) SetRgba(r, g, b, a float64) {
 	cairo.SetSourceRgba(c.context, r, g, b, a)
 }
 
-func (c *cairoSurface) SetLineWidth(width float64) {
+func (c *cairoSurfaceAdapter) SetLineWidth(width float64) {
 	cairo.SetLineWidth(c.context, width)
 }
 
-func (c *cairoSurface) Stroke() {
+func (c *cairoSurfaceAdapter) Stroke() {
 	cairo.Stroke(c.context)
 }
 
-func (c *cairoSurface) Arc(xc float64, yc float64, radius float64, angle1 float64, angle2 float64) {
+func (c *cairoSurfaceAdapter) Arc(xc float64, yc float64, radius float64, angle1 float64, angle2 float64) {
 	cairo.Arc(c.context, xc, yc, radius, angle1, angle2)
 }
 
-func (c *cairoSurface) DrawRectangle(x float64, y float64, width float64, height float64) {
+func (c *cairoSurfaceAdapter) DrawRectangle(x float64, y float64, width float64, height float64) {
 	fmt.Println("DRAW RECT:", x, y, width, height)
 	cairo.MakeRectangle(c.context, x, y, width, height)
 }
 
-func (c *cairoSurface) Fill() {
+func (c *cairoSurfaceAdapter) Fill() {
 	cairo.Fill(c.context)
 }
 
-func (c *cairoSurface) FillPreserve() {
+func (c *cairoSurfaceAdapter) FillPreserve() {
 	cairo.FillPreserve(c.context)
 }
 
-func (c *cairoSurface) getYOffsetFor(d Displayable) float64 {
+func (c *cairoSurfaceAdapter) getYOffsetFor(d Displayable) float64 {
 	current := d
 	offset := 0.0
 	for current != nil {
-		offset += current.GetY()
+		offset += math.Max(0, current.GetY())
 		current = d.GetParent()
 	}
 	return offset
 }
 
-func (s *cairoSurface) getXOffsetFor(d Displayable) float64 {
+func (s *cairoSurfaceAdapter) getXOffsetFor(d Displayable) float64 {
 	current := d
 	offset := 0.0
 	for current != nil {
-		offset += current.GetX()
+		offset += math.Max(0, current.GetX())
 		current = d.GetParent()
 	}
 	return offset
 }
 
-func (c *cairoSurface) GetOffsetSurfaceFor(d Displayable) Surface {
-	fmt.Println("CairoGetOffSurfaceFor!")
+func (c *cairoSurfaceAdapter) GetOffsetSurfaceFor(d Displayable) Surface {
+	fmt.Println("Cairo.GetOffSurfaceFor:", d.GetId())
 	x := c.getXOffsetFor(d)
 	y := c.getYOffsetFor(d)
 	return &SurfaceDelegate{
@@ -73,6 +74,6 @@ func (c *cairoSurface) GetOffsetSurfaceFor(d Displayable) Surface {
 	}
 }
 
-func NewCairoSurface(cairo *cairo.Cairo) Surface {
-	return &cairoSurface{context: cairo}
+func NewCairoSurfaceAdapter(cairo *cairo.Cairo) Surface {
+	return &cairoSurfaceAdapter{context: cairo}
 }

--- a/src/display/component.go
+++ b/src/display/component.go
@@ -561,6 +561,8 @@ func (s *Component) Draw(surface Surface) {
 	// smarter with not drawing fully occluded entities.
 	DrawRectangle(surface, s)
 	for _, child := range s.children {
+		// Create an surface delegate that includes an appropriate offset
+		// for each child and send that to the Child's Draw() method.
 		child.Draw(surface)
 	}
 }

--- a/src/display/component.go
+++ b/src/display/component.go
@@ -525,6 +525,24 @@ func (s *Component) GetFilteredChildren(filter DisplayableFilter) []Displayable 
 	return result
 }
 
+func (s *Component) GetYOffset() float64 {
+	offset := math.Max(0.0, s.GetY())
+	parent := s.GetParent()
+	if parent != nil {
+		offset = offset + parent.GetYOffset()
+	}
+	return offset
+}
+
+func (s *Component) GetXOffset() float64 {
+	offset := math.Max(0.0, s.GetX())
+	parent := s.GetParent()
+	if parent != nil {
+		offset = offset + parent.GetXOffset()
+	}
+	return offset
+}
+
 func (s *Component) GetPath() string {
 	parent := s.GetParent()
 	localPath := "/" + s.GetId()
@@ -560,10 +578,12 @@ func (s *Component) Draw(surface Surface) {
 	// over the parents (for now anyway). Eventually, we can probably get
 	// smarter with not drawing fully occluded entities.
 	DrawRectangle(surface, s)
+	childSurface := surface.GetOffsetSurfaceFor(s)
+
 	for _, child := range s.children {
 		// Create an surface delegate that includes an appropriate offset
 		// for each child and send that to the Child's Draw() method.
-		child.Draw(surface.GetOffsetSurfaceFor(child))
+		child.Draw(childSurface)
 	}
 }
 

--- a/src/display/component.go
+++ b/src/display/component.go
@@ -563,7 +563,7 @@ func (s *Component) Draw(surface Surface) {
 	for _, child := range s.children {
 		// Create an surface delegate that includes an appropriate offset
 		// for each child and send that to the Child's Draw() method.
-		child.Draw(surface)
+		child.Draw(surface.GetOffsetSurfaceFor(child))
 	}
 }
 

--- a/src/display/component_test.go
+++ b/src/display/component_test.go
@@ -207,6 +207,39 @@ func TestBaseComponent(t *testing.T) {
 		assert.Equal(t, four.GetPath(), "/root/one/four")
 	})
 
+	t.Run("GetOffsetFor", func(t *testing.T) {
+		t.Run("Root at 0,0", func(t *testing.T) {
+			root, _ := Box(NewBuilder())
+			xOffset := root.GetXOffset()
+			yOffset := root.GetYOffset()
+			assert.Equal(t, xOffset, 0)
+			assert.Equal(t, yOffset, 0)
+		})
+
+		t.Run("Root at offset", func(t *testing.T) {
+			root, _ := Box(NewBuilder(), X(10), Y(15))
+			xOffset := root.GetXOffset()
+			yOffset := root.GetYOffset()
+			assert.Equal(t, xOffset, 10)
+			assert.Equal(t, yOffset, 15)
+		})
+
+		t.Run("Child at double offset", func(t *testing.T) {
+			var nestedChild Displayable
+			root, _ := Box(NewBuilder(), Padding(10), Children(func(b Builder) {
+				Box(b, Padding(15), Children(func() {
+					nestedChild, _ = Box(b, Padding(10))
+				}))
+			}))
+			root.Layout()
+
+			xOffset := nestedChild.GetXOffset()
+			yOffset := nestedChild.GetYOffset()
+			assert.Equal(t, xOffset, 25)
+			assert.Equal(t, yOffset, 25)
+		})
+	})
+
 	t.Run("Padding", func(t *testing.T) {
 		t.Run("Applying Padding spreads to all four sides", func(t *testing.T) {
 			root, _ := TestComponent(NewBuilder(), Padding(10))
@@ -252,9 +285,13 @@ func TestBaseComponent(t *testing.T) {
 		root.Width(200)
 		assert.Equal(t, root.AddChild(one), 1)
 		assert.Equal(t, root.AddChild(two), 2)
+
 		assert.Equal(t, one.GetParent().GetId(), root.GetId())
 		assert.Equal(t, two.GetParent().GetId(), root.GetId())
-		assert.Nil(t, root.GetParent())
+
+		if root.GetParent() != nil {
+			t.Error("Expected root.GetParent() to be nil")
+		}
 	})
 
 	t.Run("GetChildCount", func(t *testing.T) {

--- a/src/display/fake_surface.go
+++ b/src/display/fake_surface.go
@@ -1,7 +1,5 @@
 package display
 
-import "errors"
-
 type SurfaceCommand struct {
 	Name string
 	Args []interface{}
@@ -52,11 +50,6 @@ func (s *FakeSurface) FillPreserve() {
 	s.commands = append(s.commands, SurfaceCommand{Name: "FillPreserve"})
 }
 
-func (s *FakeSurface) Push(d Displayable) error {
-	return errors.New("Unsupported method")
-}
-
-func (s *FakeSurface) GetRoot() Displayable {
-	// Not sure how to throw when error is not part of the interface. :-(
-	panic("Unsupported method")
+func (s *FakeSurface) GetOffsetSurfaceFor(d Displayable) Surface {
+	return nil
 }

--- a/src/display/glfw_window.go
+++ b/src/display/glfw_window.go
@@ -82,7 +82,7 @@ func (g *GlfwWindowComponent) initSurface() {
 	// Create the Epiphyte SurfaceDelegate (manages offset) ->
 	// Cairo Surface Adapter (indirection for Cairo context w/API calls) ->
 	// Native CGO library Cairo surface wrapper
-	g.cairoSurfaceAdapter = NewCairoSurface(g.cairoGlSurface.Context())
+	g.cairoSurfaceAdapter = NewCairoSurfaceAdapter(g.cairoGlSurface.Context())
 	// g.surfaceDelegate = NewSurfaceDelegate(g.cairoSurfaceAdapter)
 }
 

--- a/src/display/glfw_window.go
+++ b/src/display/glfw_window.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"errors"
+	"fmt"
 	"github.com/go-gl/gl/v2.1/gl"
 	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/golang-ui/cairo/cairogl"
@@ -25,13 +26,15 @@ type GlfwWindowComponent struct {
 }
 
 func (g *GlfwWindowComponent) updateSize(width, height int) {
-	g.Width(float64(width))
-	g.Height(float64(height))
+	if float64(width) != g.GetWidth() || float64(height) != g.GetHeight() {
+		g.Width(float64(width))
+		g.Height(float64(height))
 
-	// Pull them from the component in order to respect layout constraints.
-	g.cairoSurface.Update(int(g.GetWidth()), int(g.GetHeight()))
-	// enqueue a render request
-	g.LayoutDrawAndPaint()
+		// Pull them from the component in order to respect layout constraints.
+		g.cairoSurface.Update(int(g.GetWidth()), int(g.GetHeight()))
+		// enqueue a render request
+		g.LayoutDrawAndPaint()
+	}
 }
 
 func (g *GlfwWindowComponent) createSurface() Surface {
@@ -97,6 +100,7 @@ func (g *GlfwWindowComponent) Loop() {
 	g.initGlfw()
 	g.initGl()
 	g.surface = g.createSurface()
+	g.LayoutDrawAndPaint()
 
 	// Clean up GL and GLFW entities before closing
 	defer g.OnClose()
@@ -109,7 +113,9 @@ func (g *GlfwWindowComponent) Loop() {
 		}
 
 		g.ProcessUserInput()
-		g.LayoutDrawAndPaint()
+		// Don't want to force layouts on every render.
+		// Need a layout engine to determine when/what to Layout()
+		// g.LayoutDrawAndPaint()
 
 		// Wait for whatever amount of time remains between how long we just spent,
 		// and when the next frame (at fps) should be.
@@ -135,6 +141,7 @@ func (g *GlfwWindowComponent) GlPaint() {
 }
 
 func (g *GlfwWindowComponent) LayoutDrawAndPaint() {
+	fmt.Println("LayoutDrawAndPaint")
 	g.GlLayout()
 	g.GlDraw()
 	g.GlPaint()

--- a/src/display/interfaces.go
+++ b/src/display/interfaces.go
@@ -14,6 +14,9 @@ type Composable interface {
 	GetChildAt(index int) Displayable
 	GetChildren() []Displayable
 	GetFilteredChildren(DisplayableFilter) []Displayable
+
+	GetYOffset() float64
+	GetXOffset() float64
 	// TODO(lbayes): This should be capitalized so that external components can implement it.
 	setParent(parent Displayable)
 }

--- a/src/display/rectangle.go
+++ b/src/display/rectangle.go
@@ -1,10 +1,25 @@
 package display
 
-func DrawRectangle(surface Surface, disp Displayable) {
-	surface.MoveTo(disp.GetX(), disp.GetY())
-	surface.SetRgba(1, 1, 0, 1)
+func getDepth(sum int, d Displayable) int {
+	parent := d.GetParent()
+	if parent == nil {
+		return sum
+	}
+	sum++
+	return getDepth(sum, parent)
+}
 
-	surface.DrawRectangle(disp.GetX(), disp.GetY(), disp.GetWidth(), disp.GetHeight())
+func DrawRectangle(surface Surface, d Displayable) {
+	colors := []int{0xffcc00, 0xccff00, 0xcc00ff, 0x00ccff}
+
+	depthFromRoot := getDepth(0, d)
+	index := depthFromRoot % (len(colors) - 1)
+	r, g, b := HexIntToRgb(colors[index])
+
+	surface.MoveTo(d.GetX(), d.GetY())
+	surface.SetRgba(float64(r), float64(g), float64(b), 1)
+
+	surface.DrawRectangle(d.GetX(), d.GetY(), d.GetWidth(), d.GetHeight())
 	surface.FillPreserve()
 
 	surface.SetLineWidth(1)

--- a/src/display/surface.go
+++ b/src/display/surface.go
@@ -10,9 +10,7 @@ type Surface interface {
 	SetRgba(r, g, b, a float64)
 	Stroke()
 
-	GetRoot() Displayable
-	Push(d Displayable) error
-	// PushStyle(styleAttrs *Attrs) error
+	GetOffsetSurfaceFor(d Displayable) Surface
 
 	/*
 		NewPath()

--- a/src/display/surface_delegate.go
+++ b/src/display/surface_delegate.go
@@ -1,41 +1,80 @@
 package display
 
+import "fmt"
+
 type SurfaceDelegate struct {
-	DelegateTo Surface
+	delegateTo Surface
+	offsetX    float64
+	offsetY    float64
 }
 
 func (s *SurfaceDelegate) MoveTo(x float64, y float64) {
-	s.DelegateTo.MoveTo(x, y)
+	s.delegateTo.MoveTo(x+s.offsetX, y+s.offsetY)
 }
 
 func (s *SurfaceDelegate) SetRgba(r, g, b, a float64) {
-	s.DelegateTo.SetRgba(r, g, b, a)
+	s.delegateTo.SetRgba(r, g, b, a)
 }
 
 func (s *SurfaceDelegate) SetLineWidth(width float64) {
-	s.DelegateTo.SetLineWidth(width)
+	s.delegateTo.SetLineWidth(width)
 }
 
 func (s *SurfaceDelegate) Stroke() {
-	s.DelegateTo.Stroke()
+	s.delegateTo.Stroke()
 }
 
 func (s *SurfaceDelegate) Arc(xc float64, yc float64, radius float64, angle1 float64, angle2 float64) {
-	s.DelegateTo.Arc(xc, yc, radius, angle1, angle2)
+	xc += s.offsetX
+	yc += s.offsetY
+	s.delegateTo.Arc(xc, yc, radius, angle1, angle2)
 }
 
 func (s *SurfaceDelegate) DrawRectangle(x float64, y float64, width float64, height float64) {
-	s.DelegateTo.DrawRectangle(x, y, width, height)
+	x += s.offsetX
+	y += s.offsetY
+	s.delegateTo.DrawRectangle(x, y, width, height)
 }
 
 func (s *SurfaceDelegate) Fill() {
-	s.DelegateTo.Fill()
+	s.delegateTo.Fill()
 }
 
 func (s *SurfaceDelegate) FillPreserve() {
-	s.DelegateTo.FillPreserve()
+	s.delegateTo.FillPreserve()
+}
+
+func (s *SurfaceDelegate) getYOffsetFor(d Displayable) float64 {
+	current := d
+	offset := 0.0
+	for current != nil {
+		offset += current.GetY()
+		current = d.GetParent()
+	}
+	return offset
+}
+
+func (s *SurfaceDelegate) getXOffsetFor(d Displayable) float64 {
+	current := d
+	offset := 0.0
+	for current != nil {
+		offset += current.GetX()
+		current = d.GetParent()
+	}
+	return offset
+}
+
+func (s *SurfaceDelegate) GetOffsetSurfaceFor(d Displayable) Surface {
+	fmt.Println("Surface Delegate GetOffsetSurface")
+	x := s.getXOffsetFor(d)
+	y := s.getYOffsetFor(d)
+	return &SurfaceDelegate{
+		delegateTo: s.delegateTo,
+		offsetX:    x,
+		offsetY:    y,
+	}
 }
 
 func NewSurfaceDelegate(delegateTo Surface) *SurfaceDelegate {
-	return &SurfaceDelegate{DelegateTo: delegateTo}
+	return &SurfaceDelegate{delegateTo: delegateTo}
 }

--- a/src/display/surface_delegate.go
+++ b/src/display/surface_delegate.go
@@ -1,6 +1,9 @@
 package display
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+)
 
 type SurfaceDelegate struct {
 	delegateTo Surface
@@ -31,8 +34,10 @@ func (s *SurfaceDelegate) Arc(xc float64, yc float64, radius float64, angle1 flo
 }
 
 func (s *SurfaceDelegate) DrawRectangle(x float64, y float64, width float64, height float64) {
+	fmt.Println("DRAW offset!", s.offsetX, s.offsetY)
 	x += s.offsetX
 	y += s.offsetY
+	fmt.Println("DRAW RECT!", x, y, width, height)
 	s.delegateTo.DrawRectangle(x, y, width, height)
 }
 
@@ -48,7 +53,7 @@ func (s *SurfaceDelegate) getYOffsetFor(d Displayable) float64 {
 	current := d
 	offset := 0.0
 	for current != nil {
-		offset += current.GetY()
+		offset += math.Max(0, current.GetY())
 		current = d.GetParent()
 	}
 	return offset
@@ -58,18 +63,22 @@ func (s *SurfaceDelegate) getXOffsetFor(d Displayable) float64 {
 	current := d
 	offset := 0.0
 	for current != nil {
-		offset += current.GetX()
+		offset += math.Max(0, current.GetX())
 		current = d.GetParent()
 	}
 	return offset
 }
 
 func (s *SurfaceDelegate) GetOffsetSurfaceFor(d Displayable) Surface {
+	return NewSurfaceDelegateFor(d, s)
+}
+
+func NewSurfaceDelegateFor(d Displayable, delegateTo Surface) Surface {
 	fmt.Println("Surface Delegate GetOffsetSurface")
-	x := s.getXOffsetFor(d)
-	y := s.getYOffsetFor(d)
+	x := d.GetXOffset()
+	y := d.GetYOffset()
 	return &SurfaceDelegate{
-		delegateTo: s.delegateTo,
+		delegateTo: delegateTo,
 		offsetX:    x,
 		offsetY:    y,
 	}

--- a/src/display/surface_delegate.go
+++ b/src/display/surface_delegate.go
@@ -1,9 +1,6 @@
 package display
 
-import (
-	"fmt"
-	"math"
-)
+import ()
 
 type SurfaceDelegate struct {
 	delegateTo Surface
@@ -34,10 +31,8 @@ func (s *SurfaceDelegate) Arc(xc float64, yc float64, radius float64, angle1 flo
 }
 
 func (s *SurfaceDelegate) DrawRectangle(x float64, y float64, width float64, height float64) {
-	fmt.Println("DRAW offset!", s.offsetX, s.offsetY)
 	x += s.offsetX
 	y += s.offsetY
-	fmt.Println("DRAW RECT!", x, y, width, height)
 	s.delegateTo.DrawRectangle(x, y, width, height)
 }
 
@@ -49,41 +44,14 @@ func (s *SurfaceDelegate) FillPreserve() {
 	s.delegateTo.FillPreserve()
 }
 
-func (s *SurfaceDelegate) getYOffsetFor(d Displayable) float64 {
-	current := d
-	offset := 0.0
-	for current != nil {
-		offset += math.Max(0, current.GetY())
-		current = d.GetParent()
-	}
-	return offset
-}
-
-func (s *SurfaceDelegate) getXOffsetFor(d Displayable) float64 {
-	current := d
-	offset := 0.0
-	for current != nil {
-		offset += math.Max(0, current.GetX())
-		current = d.GetParent()
-	}
-	return offset
-}
-
 func (s *SurfaceDelegate) GetOffsetSurfaceFor(d Displayable) Surface {
 	return NewSurfaceDelegateFor(d, s)
 }
 
 func NewSurfaceDelegateFor(d Displayable, delegateTo Surface) Surface {
-	fmt.Println("Surface Delegate GetOffsetSurface")
-	x := d.GetXOffset()
-	y := d.GetYOffset()
 	return &SurfaceDelegate{
 		delegateTo: delegateTo,
-		offsetX:    x,
-		offsetY:    y,
+		offsetX:    d.GetXOffset(),
+		offsetY:    d.GetYOffset(),
 	}
-}
-
-func NewSurfaceDelegate(delegateTo Surface) *SurfaceDelegate {
-	return &SurfaceDelegate{delegateTo: delegateTo}
 }

--- a/src/examples/boxes/main.go
+++ b/src/examples/boxes/main.go
@@ -12,7 +12,7 @@ func init() {
 func createWindow() (Displayable, error) {
 	return GlfwWindow(NewBuilder(), Padding(10), Title("Test Title"), Width(640), Height(480), GlfwFrameRate(10), Children(func(b Builder) {
 		Box(b, Id("header"), Padding(5), FlexHeight(1), FlexWidth(1))
-		HBox(b, Id("body"), Padding(5), FlexHeight(1), FlexWidth(1), Children(func(b Builder) {
+		HBox(b, Id("body"), Padding(5), FlexHeight(3), FlexWidth(1), Children(func(b Builder) {
 			Box(b, Id("leftNav"), FlexWidth(1), FlexHeight(1))
 			Box(b, Id("content"), FlexWidth(3), FlexHeight(1))
 		}))

--- a/src/examples/boxes/main.go
+++ b/src/examples/boxes/main.go
@@ -10,9 +10,9 @@ func init() {
 }
 
 func createWindow() (Displayable, error) {
-	return GlfwWindow(NewBuilder(), Title("Test Title"), Width(640), Height(480), GlfwFrameRate(10), Children(func(b Builder) {
-		Box(b, Id("header"), FlexHeight(1), FlexWidth(1))
-		HBox(b, Id("body"), FlexHeight(1), FlexWidth(1), Children(func(b Builder) {
+	return GlfwWindow(NewBuilder(), Padding(10), Title("Test Title"), Width(640), Height(480), GlfwFrameRate(10), Children(func(b Builder) {
+		Box(b, Id("header"), Padding(5), FlexHeight(1), FlexWidth(1))
+		HBox(b, Id("body"), Padding(5), FlexHeight(1), FlexWidth(1), Children(func(b Builder) {
 			Box(b, Id("leftNav"), FlexWidth(1), FlexHeight(1))
 			Box(b, Id("content"), FlexWidth(3), FlexHeight(1))
 		}))


### PR DESCRIPTION
Any given component can draw into their provided surface with local x & y values, and these will be translated into global values by a set of parent surface delegates.