### PR TITLE
Fixed color values on SetRgba calls

### DIFF
--- a/src/display/cairo_surface.go
+++ b/src/display/cairo_surface.go
@@ -4,6 +4,14 @@ import (
 	"github.com/golang-ui/cairo"
 )
 
+func uintColorToFloat(color uint) float64 {
+	if color == 0 {
+		return 0
+	} else {
+		return float64(color) / 255.0
+	}
+}
+
 type cairoSurfaceAdapter struct {
 	context *cairo.Cairo
 }
@@ -12,8 +20,8 @@ func (c *cairoSurfaceAdapter) MoveTo(x float64, y float64) {
 	cairo.MoveTo(c.context, x, y)
 }
 
-func (c *cairoSurfaceAdapter) SetRgba(r, g, b, a float64) {
-	cairo.SetSourceRgba(c.context, r, g, b, a)
+func (c *cairoSurfaceAdapter) SetRgba(r, g, b, a uint) {
+	cairo.SetSourceRgba(c.context, uintColorToFloat(r), uintColorToFloat(g), uintColorToFloat(b), uintColorToFloat(a))
 }
 
 func (c *cairoSurfaceAdapter) SetLineWidth(width float64) {

--- a/src/display/colors.go
+++ b/src/display/colors.go
@@ -1,6 +1,6 @@
 package display
 
-func HexIntToRgb(value int) (r, g, b int) {
+func HexIntToRgb(value uint) (r, g, b uint) {
 	r = (value >> 16) & 0xff
 	g = (value >> 8) & 0xff
 	b = (value) & 0xff

--- a/src/display/fake_surface.go
+++ b/src/display/fake_surface.go
@@ -18,7 +18,7 @@ func (s *FakeSurface) MoveTo(x float64, y float64) {
 	s.commands = append(s.commands, SurfaceCommand{Name: "MoveTo", Args: args})
 }
 
-func (s *FakeSurface) SetRgba(r, g, b, a float64) {
+func (s *FakeSurface) SetRgba(r, g, b, a uint) {
 	args := []interface{}{r, g, b, a}
 	s.commands = append(s.commands, SurfaceCommand{Name: "SetRgba", Args: args})
 }

--- a/src/display/fake_surface_test.go
+++ b/src/display/fake_surface_test.go
@@ -13,15 +13,15 @@ func TestFakeSurface(t *testing.T) {
 	})
 
 	t.Run("SetRgba", func(t *testing.T) {
-		instance.SetRgba(0.8, 0.7, 0.6, 0.5)
+		instance.SetRgba(0x00, 0xff, 0xcc, 0xff)
 		commands := instance.GetCommands()
 
 		command := commands[0]
 		assert.Equal(t, command.Name, "SetRgba")
 		// Args are turned into strings for easier test comparisons
-		assert.Equal(t, command.Args[0], 0.8)
-		assert.Equal(t, command.Args[1], 0.7)
-		assert.Equal(t, command.Args[2], 0.6)
-		assert.Equal(t, command.Args[3], 0.5)
+		assert.Equal(t, command.Args[0], uint(0x00))
+		assert.Equal(t, command.Args[1], uint(0xff))
+		assert.Equal(t, command.Args[2], uint(0xcc))
+		assert.Equal(t, command.Args[3], uint(0xff))
 	})
 }

--- a/src/display/glfw_window.go
+++ b/src/display/glfw_window.go
@@ -121,7 +121,8 @@ func (g *GlfwWindowComponent) Loop() {
 		// Wait for whatever amount of time remains between how long we just spent,
 		// and when the next frame (at fps) should be.
 		waitDuration := time.Second/time.Duration(g.GetFrameRate()) - time.Since(t)
-		fmt.Println("looping", waitDuration)
+		// NOTE: Looping stops when mouse is pressed on window resizer (on macOS, but not i3wm/Ubuntu Linux)
+		// fmt.Println("looping", waitDuration)
 		time.Sleep(waitDuration)
 	}
 }

--- a/src/display/glfw_window.go
+++ b/src/display/glfw_window.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const DefaultFrameRate = 12
+const DefaultFrameRate = 60
 const DefaultWindowWidth = 1024
 const DefaultWindowHeight = 768
 const DefaultWindowTitle = "Default Title"
@@ -121,6 +121,7 @@ func (g *GlfwWindowComponent) Loop() {
 		// Wait for whatever amount of time remains between how long we just spent,
 		// and when the next frame (at fps) should be.
 		waitDuration := time.Second/time.Duration(g.GetFrameRate()) - time.Since(t)
+		fmt.Println("looping", waitDuration)
 		time.Sleep(waitDuration)
 	}
 }

--- a/src/display/label.go
+++ b/src/display/label.go
@@ -1,0 +1,13 @@
+package display
+
+import "fmt"
+
+type LabelComponent struct {
+	Component
+}
+
+func (l *LabelComponent) Draw(surface Surface) {
+	fmt.Println("Label.Draw called!")
+}
+
+var Label = NewComponentFactoryFrom(Box)

--- a/src/display/label_test.go
+++ b/src/display/label_test.go
@@ -1,0 +1,17 @@
+package display
+
+import (
+	"assert"
+	"testing"
+)
+
+func TestLabel(t *testing.T) {
+	t.Run("Simple Label", func(t *testing.T) {
+		label, _ := Label(NewBuilder(), Title("Hello World"))
+		assert.Equal(t, label.GetTitle(), "Hello World")
+	})
+
+	t.Run("Label draws", func(t *testing.T) {
+
+	})
+}

--- a/src/display/layout.go
+++ b/src/display/layout.go
@@ -20,16 +20,9 @@ const (
 type LayoutTypeValue int
 
 const (
-	// GROSS! I'm sure I've done something wrong here, but the "zero value" for
-	// an enum field (above) is 0. This means that not setting the enum will
-	// automatically set it to the first value in this list. :barf:
-	// DO NOT SORT THESE ALPHABETICALLY!
 	StackLayoutType = iota
-	// DO NOT SORT
 	VerticalFlowLayoutType
-	// DO NOT SORT
 	HorizontalFlowLayoutType
-	// DO NOT SORT
 	RowLayoutType
 )
 

--- a/src/display/layout_test.go
+++ b/src/display/layout_test.go
@@ -43,9 +43,8 @@ func createTwoBoxes() (Displayable, Displayable) {
 }
 
 func TestLayout(t *testing.T) {
-	root := NewComponent()
-
 	t.Run("Call LayoutHandler", func(t *testing.T) {
+		root := NewComponent()
 		assert.NotNil(t, root)
 	})
 
@@ -90,7 +89,7 @@ func TestLayout(t *testing.T) {
 
 	t.Run("GetFlexibleChildren", func(t *testing.T) {
 		t.Run("Returns non nil slice", func(t *testing.T) {
-			root = NewComponent()
+			root := NewComponent()
 			hDelegate := &horizontalDelegate{}
 			children := getFlexibleChildren(hDelegate, root)
 			if children == nil {

--- a/src/display/rectangle.go
+++ b/src/display/rectangle.go
@@ -10,20 +10,19 @@ func getDepth(sum int, d Displayable) int {
 }
 
 func DrawRectangle(surface Surface, d Displayable) {
-	colors := []int{0xffcc00, 0xccff00, 0xcc00ff, 0x00ccff}
-	// colors := []float64{0x3d5476, 0xffa500, 0xccdeff, 0xffedcc}
+	colors := []uint{0x333333, 0x666666, 0x999999, 0xcccccc}
 
 	depthFromRoot := getDepth(0, d)
 	index := depthFromRoot % (len(colors) - 1)
 	r, g, b := HexIntToRgb(colors[index])
 
 	surface.MoveTo(d.GetX(), d.GetY())
-	surface.SetRgba(float64(r), float64(g), float64(b), 1)
+	surface.SetRgba(r, g, b, 255)
 
 	surface.DrawRectangle(d.GetX(), d.GetY(), d.GetWidth(), d.GetHeight())
 	surface.FillPreserve()
 
 	surface.SetLineWidth(1)
-	surface.SetRgba(0, 0, 0, 1)
+	surface.SetRgba(0x33, 0x33, 0x33, 0xff)
 	surface.Stroke()
 }

--- a/src/display/rectangle.go
+++ b/src/display/rectangle.go
@@ -11,6 +11,7 @@ func getDepth(sum int, d Displayable) int {
 
 func DrawRectangle(surface Surface, d Displayable) {
 	colors := []int{0xffcc00, 0xccff00, 0xcc00ff, 0x00ccff}
+	// colors := []float64{0x3d5476, 0xffa500, 0xccdeff, 0xffedcc}
 
 	depthFromRoot := getDepth(0, d)
 	index := depthFromRoot % (len(colors) - 1)

--- a/src/display/surface.go
+++ b/src/display/surface.go
@@ -7,7 +7,7 @@ type Surface interface {
 	Fill()
 	FillPreserve()
 	SetLineWidth(width float64)
-	SetRgba(r, g, b, a float64)
+	SetRgba(r, g, b, a uint)
 	Stroke()
 
 	// Provides offset surface for nested components so that they can use

--- a/src/display/surface.go
+++ b/src/display/surface.go
@@ -10,7 +10,13 @@ type Surface interface {
 	SetRgba(r, g, b, a float64)
 	Stroke()
 
+	// Provides offset surface for nested components so that they can use
+	// local coordinates for positioning.
 	GetOffsetSurfaceFor(d Displayable) Surface
+
+	// SelectFontFace(family string, slant FontSlant, weight FontWeight)
+	// SetFontOptions(options *FontOptions)
+	// SetFontFace(fontFace *FontFace)
 
 	/*
 		NewPath()

--- a/src/display/surface_delegate.go
+++ b/src/display/surface_delegate.go
@@ -12,7 +12,7 @@ func (s *SurfaceDelegate) MoveTo(x float64, y float64) {
 	s.delegateTo.MoveTo(x+s.offsetX, y+s.offsetY)
 }
 
-func (s *SurfaceDelegate) SetRgba(r, g, b, a float64) {
+func (s *SurfaceDelegate) SetRgba(r, g, b, a uint) {
 	s.delegateTo.SetRgba(r, g, b, a)
 }
 


### PR DESCRIPTION
The Cairo api wants float64 values (0-1), but it's easier to represent color in the UI as hex values (0-255, or 0x00-0xff).

Introduced conversion at the interface between Cairo and Epiphyte.