### PR TITLE
Updated assert.Equal to use fmt.Sprintf for scalar values.

### DIFF
--- a/src/display/component_test.go
+++ b/src/display/component_test.go
@@ -9,13 +9,13 @@ import (
 func TestBaseComponent(t *testing.T) {
 	t.Run("Generated ID", func(t *testing.T) {
 		root := NewComponent()
-		assert.Equal(t, len(root.GetID()), 20)
+		assert.Equal(t, len(root.GetID()), 20, "GetId")
 	})
 
 	t.Run("Default Size", func(t *testing.T) {
 		box, _ := Box(NewBuilder())
-		assert.Equal(t, box.GetFixedWidth(), -1)
-		assert.Equal(t, box.GetFixedHeight(), -1)
+		assert.Equal(t, box.GetFixedWidth(), -1, "FixedWidth")
+		assert.Equal(t, box.GetFixedHeight(), -1, "FixedHeight")
 	})
 
 	t.Run("Default Size after Layout", func(t *testing.T) {

--- a/src/display/glfw_window.go
+++ b/src/display/glfw_window.go
@@ -8,7 +8,7 @@ import (
 
 type GlfwWindowResizeHandler func(width, height int)
 
-const DefaultFrameRate = 2
+const DefaultFrameRate = 60
 const DefaultWindowWidth = 800
 const DefaultWindowHeight = 600
 const DefaultWindowTitle = "Default Title"

--- a/src/display/rectangle.go
+++ b/src/display/rectangle.go
@@ -10,9 +10,7 @@ func getDepth(sum int, d Displayable) int {
 }
 
 func DrawRectangle(surface Surface, d Displayable) {
-
 	colors := []uint{0xccccccff, 0x333333ff, 0x666666ff, 0x999999ff}
-
 	depthFromRoot := getDepth(0, d)
 	index := depthFromRoot % (len(colors) - 1)
 	color := colors[index]

--- a/src/display/rectangle_test.go
+++ b/src/display/rectangle_test.go
@@ -6,14 +6,23 @@ import (
 )
 
 func TestDrawRectangle(t *testing.T) {
-	surface := &FakeSurface{}
 
-	t.Run("Draw with Box", func(t *testing.T) {
-		sprite := NewComponent()
-		DrawRectangle(surface, sprite)
+	t.Run("Sends some commands to surface", func(t *testing.T) {
+		surface := &FakeSurface{}
+		instance := NewComponent()
+		DrawRectangle(surface, instance)
 
 		commands := surface.GetCommands()
 		assert.NotNil(t, commands)
-		// assert.TEqual(t, len(commands), 0)
+	})
+
+	t.Run("Uses zero x and y", func(t *testing.T) {
+		surface := &FakeSurface{}
+		instance, _ := TestComponent(NewBuilder(), Width(100), Height(120))
+		DrawRectangle(surface, instance)
+
+		commands := surface.GetCommands()
+		assert.Equal(t, commands[0].Name, "SetFillColor", "Command Name")
+		assert.Equal(t, commands[0].Args[0], 0xccccccff, "Color Value")
 	})
 }


### PR DESCRIPTION
This allows floats to be matched by at least some kind of approximation
that seems decent enough for layout rules.