### PR TITLE
Initial options implementation

### DIFF
--- a/src/display/component.go
+++ b/src/display/component.go
@@ -14,6 +14,8 @@ const DefaultFontFace = "sans"
 const DefaultStrokeColor = 0x333333ff
 const DefaultStrokeSize = 2
 
+type SelectOptions map[string][]ComponentOption
+
 // Component is a concrete base component implementation made public for
 // composition, not instantiation.
 type Component struct {
@@ -22,6 +24,7 @@ type Component struct {
 	model              *ComponentModel
 	composeSimple      func()
 	composeWithBuilder func(Builder)
+	selectOptions      SelectOptions
 }
 
 func (s *Component) GetID() string {
@@ -31,6 +34,22 @@ func (s *Component) GetID() string {
 	}
 
 	return model.ID
+}
+
+func (s *Component) PushSelector(sel string, opts ...ComponentOption) error {
+	selOptions := s.GetSelectOptions()
+	if selOptions[sel] != nil {
+		return errors.New("duplicate selector found with:" + sel)
+	}
+	selOptions[sel] = opts
+	return nil
+}
+
+func (s *Component) GetSelectOptions() SelectOptions {
+	if s.selectOptions == nil {
+		s.selectOptions = make(map[string][]ComponentOption)
+	}
+	return s.selectOptions
 }
 
 func (s *Component) Composer(composer interface{}) error {

--- a/src/display/component_factory_test.go
+++ b/src/display/component_factory_test.go
@@ -172,13 +172,4 @@ func TestComponentFactory(t *testing.T) {
 			t.Error("Expected Padding to update PaddingBottom")
 		}
 	})
-
-	t.Run("NewComponentFactoryFrom", func(t *testing.T) {
-		BigVBox := NewComponentFactoryFrom(VBox, MinWidth(200), MinHeight(200))
-
-		instance, _ := BigVBox(NewBuilder())
-		if instance.GetMinWidth() != 200 {
-			t.Error("Expected default MinWidth")
-		}
-	})
 }

--- a/src/display/component_test.go
+++ b/src/display/component_test.go
@@ -361,4 +361,22 @@ func TestBaseComponent(t *testing.T) {
 		assert.Equal(t, root.GetBgColor(), 0x999999ff, "BgColor")
 		assert.Equal(t, root.GetStrokeColor(), 0x333333ff, "StrokeColor")
 	})
+
+	t.Run("PushSelector", func(t *testing.T) {
+		// Outer node does not receive selector value
+		root, _ := Box(NewBuilder(), Children(func(b Builder) {
+			Selector(b, "*", BgColor(0xffcc00ff))
+			// Should receive the provided selector value
+			Box(b, ID("one"))
+			// Override the selector with concrete value
+			Box(b, ID("two"), BgColor(0xff00ffff))
+		}))
+
+		opts := root.GetSelectOptions()
+		assert.NotNil(t, opts["*"], "Opts collected")
+
+		assert.Equal(t, root.GetBgColor(), DefaultBgColor, "one bgcolor")
+		assert.Equal(t, root.GetChildAt(0).GetBgColor(), 0xffcc00ff, "one bgcolor")
+		assert.Equal(t, root.GetChildAt(1).GetBgColor(), 0xff00ffff, "two bgcolor")
+	})
 }

--- a/src/display/interfaces.go
+++ b/src/display/interfaces.go
@@ -117,6 +117,9 @@ type Displayable interface {
 	Title(title string)
 	GetTitle() string
 	Draw(s Surface)
+
+	PushSelector(sel string, opts ...ComponentOption) error
+	GetSelectOptions() SelectOptions
 }
 
 // Window is an outermost component that manages the application event loop.

--- a/src/display/options_for.go
+++ b/src/display/options_for.go
@@ -1,0 +1,33 @@
+package display
+
+func mergeSelectOptions(result, next SelectOptions) SelectOptions {
+	for key, value := range next {
+		result[key] = value
+	}
+	return result
+}
+
+func selectorMatches(key string, d Displayable, parent Displayable) bool {
+	if key == "*" {
+		return true
+	}
+	return false
+}
+
+func OptionsFor(d Displayable, parent Displayable) []ComponentOption {
+	optionsMap := d.GetSelectOptions()
+	current := parent
+	for current != nil {
+		optionsMap = mergeSelectOptions(optionsMap, current.GetSelectOptions())
+		current = current.GetParent()
+	}
+
+	result := []ComponentOption{}
+	for key, value := range optionsMap {
+		if selectorMatches(key, d, parent) {
+			result = append(result, value...)
+		}
+	}
+
+	return result
+}

--- a/src/examples/boxes/main.go
+++ b/src/examples/boxes/main.go
@@ -11,6 +11,8 @@ func init() {
 
 func createWindow() (Displayable, error) {
 	return NanoWindow(NewBuilder(), Padding(10), Title("Test Title"), Children(func(b Builder) {
+		Selector(b, "*", BgColor(0xccccccff), FontFace("sans"), FontSize(12), FontColor(0x222222ff))
+
 		Box(b, ID("header"), Height(100), FlexWidth(1), Children(func(b Builder) {
 			Label(b, ID("title"), BgColor(0x33ff33ff), FontSize(48), Padding(10), FlexWidth(1), Height(100), Text("HELLO WORLD"))
 		}))


### PR DESCRIPTION
Introduced concept of independent collections of Options that are associated with a "Selector."

These are similar in concept to CSS, but rather than attempting to define only "Style", these are more like Traits and allow one to slice the component tree using selector syntax and apply attribute values to all matched components.

In the initial implementation, the only supported selector is, "*". More to come.

Currently struggling with ordering problems. I need to apply the other, concrete options in order to find out if the component matches a selector, but the other options may be expected to override some subset of the selector-matched options.

There is additional complexity in that the Window components are the outer nodes of the tree and therefore aren't available to Selectors at all because they necessarily already exist by the time the child Selector is created.

More exploration to come.