### PR TITLE
Apply traits to component names

### DIFF
--- a/src/display/options_for.go
+++ b/src/display/options_for.go
@@ -8,7 +8,7 @@ func mergeSelectOptions(result, next TraitOptions) TraitOptions {
 }
 
 func selectorMatches(key string, d Displayable, parent Displayable) bool {
-	if key == "*" {
+	if key == d.GetTypeName() || key == "*" {
 		return true
 	}
 	return false

--- a/src/display/trait_test.go
+++ b/src/display/trait_test.go
@@ -23,4 +23,36 @@ func TestTrait(t *testing.T) {
 		assert.Equal(t, root.GetChildAt(0).GetBgColor(), 0xffcc00ff, "one bgcolor")
 		assert.Equal(t, root.GetChildAt(1).GetBgColor(), 0xff00ffff, "two bgcolor")
 	})
+
+	t.Run("Traits applied to component type names", func(t *testing.T) {
+		var one, two, three, four Displayable
+
+		red := 0xff0000ff
+		blue := 0x00ff00ff
+		green := 0x0000ffff
+
+		// RED is the global default BgColor for FakeTraitName components.
+		FakeTraitName := NewComponentFactory("FakeTraitName", NewComponent, BgColor(red))
+
+		root, _ := Box(NewBuilder(), Children(func(b Builder) {
+			one, _ = FakeTraitName(b)
+			Box(b, Children(func() {
+				// Any FakeTraitName component instances inside of this Box, will have DEFAULT BgColor BLUE.
+				Trait(b, "FakeTraitName", BgColor(blue))
+				two, _ = FakeTraitName(b)
+				// This instance overrides the modified default color
+				three, _ = FakeTraitName(b, BgColor(green))
+				Box(b, Children(func() {
+					// Even nested children pick up the Trait definition
+					four, _ = FakeTraitName(b)
+				}))
+			}))
+		}))
+
+		assert.Equal(t, root.GetChildCount(), 2)
+		assert.Equal(t, one.GetBgColor(), red, "one")
+		assert.Equal(t, two.GetBgColor(), blue, "two")
+		assert.Equal(t, three.GetBgColor(), green, "three")
+		assert.Equal(t, four.GetBgColor(), blue, "four")
+	})
 }


### PR DESCRIPTION
Trait definitions are now being applied to nested components that have the matching name.