### PR TITLE
Fixed issue where nodes were disappearing when attempting to update them.

### DIFF
--- a/src/display/component_factory.go
+++ b/src/display/component_factory.go
@@ -85,6 +85,9 @@ func NewComponentFactory(typeName string, c componentConstructor, factoryOpts ..
 
 		// Instantiate the component from the provided factory function.
 		instance := c()
+		instance.Builder(b)
+		// Give the component a reference to the builder, so that future updates will
+		// all use the same builder stack
 		instance.TypeName(typeName)
 
 		traitOpts := OptionsFor(instance, b.Peek())

--- a/src/display/component_model.go
+++ b/src/display/component_model.go
@@ -13,6 +13,7 @@ type ComponentModel struct {
 	// layout
 	ActualHeight      float64
 	ActualWidth       float64
+	Builder           Builder
 	Disabled          bool
 	ExcludeFromLayout bool
 	FlexHeight        float64

--- a/src/display/component_test.go
+++ b/src/display/component_test.go
@@ -365,8 +365,8 @@ func TestBaseComponent(t *testing.T) {
 
 	t.Run("GetBuilder", func(t *testing.T) {
 		box, _ := Box(NewBuilder())
-		if box.GetBuilder() != nil {
-			t.Error("Only Windows have builders")
+		if box.GetBuilder() == nil {
+			t.Error("Component factory should assign the builder")
 		}
 	})
 
@@ -558,12 +558,13 @@ func TestBaseComponent(t *testing.T) {
 		// Invalidate a nested child
 		one.Invalidate()
 		// Run validation from Root
-		root.Validate()
+		dirtyNodes := root.Validate()
 
 		if firstInstanceOfTwo == two {
 			t.Error("Expected the inner component to be re-instantiated")
 		}
 
+		assert.Equal(t, len(dirtyNodes), 1)
 		assert.Equal(t, rootClosureCallCount, 1, "Root closure should NOT have been called again")
 		assert.Equal(t, oneClosureCallCount, 2, "inner closure should have run twice")
 		assert.Equal(t, one.GetChildCount(), 2, "Children are rebuilt")

--- a/src/display/interfaces.go
+++ b/src/display/interfaces.go
@@ -8,6 +8,7 @@ type DisplayableFilter = func(Displayable) bool
 // traversal.
 type Composable interface {
 	AddChild(child Displayable) int
+	Builder(b Builder)
 	Composer(composeFunc interface{}) error
 	GetBuilder() Builder
 	GetChildAt(index int) Displayable
@@ -137,7 +138,7 @@ type Displayable interface {
 	ShouldValidate() bool
 	Text(text string)
 	Title(title string)
-	Validate()
+	Validate() []Displayable
 	View(view RenderHandler)
 
 	PushTrait(sel string, opts ...ComponentOption) error

--- a/src/display/layout.go
+++ b/src/display/layout.go
@@ -104,10 +104,6 @@ func notExcludedFromLayout(d Displayable) bool {
 	return !d.GetExcludeFromLayout()
 }
 
-func isFlexible(delegate LayoutDelegate, d Displayable) bool {
-	return delegate.GetFlex(d) > 0.0
-}
-
 // Collect the layoutable children of a Displayable
 func getLayoutableChildren(d Displayable) []Displayable {
 	return d.GetFilteredChildren(notExcludedFromLayout)
@@ -115,7 +111,9 @@ func getLayoutableChildren(d Displayable) []Displayable {
 
 func getFlexibleChildren(delegate LayoutDelegate, d Displayable) []Displayable {
 	return d.GetFilteredChildren(func(child Displayable) bool {
-		return notExcludedFromLayout(child) && delegate.GetIsFlexible(child)
+		isExcluded := child.GetExcludeFromLayout()
+		isFlexible := delegate.GetIsFlexible(child)
+		return isFlexible && !isExcluded
 	})
 }
 
@@ -127,7 +125,7 @@ func getNotExcludedFromLayoutChildren(delegate LayoutDelegate, d Displayable) []
 
 func getStaticChildren(delegate LayoutDelegate, d Displayable) []Displayable {
 	return d.GetFilteredChildren(func(child Displayable) bool {
-		return notExcludedFromLayout(child) && !isFlexible(delegate, child)
+		return notExcludedFromLayout(child) && !delegate.GetIsFlexible(child)
 	})
 }
 
@@ -142,6 +140,7 @@ func getStaticSize(delegate LayoutDelegate, d Displayable) float64 {
 
 func flowScaleChildren(delegate LayoutDelegate, d Displayable) {
 	flexibleChildren := getFlexibleChildren(delegate, d)
+
 	if len(flexibleChildren) > 0 {
 
 		unitSize, remainder := flowGetUnitSize(delegate, d, flexibleChildren)

--- a/src/display/layout_test.go
+++ b/src/display/layout_test.go
@@ -212,4 +212,18 @@ func TestLayout(t *testing.T) {
 		assert.Equal(t, footer.GetHeight(), 80)
 		assert.Equal(t, content.GetHeight(), 120)
 	})
+
+	t.Run("Nested, flexible controls should expand", func(t *testing.T) {
+		root, _ := Box(NewBuilder(), ID("root"), Width(100), Children(func(b Builder) {
+			Box(b, ID("one"), FlexWidth(1), Children(func() {
+				Box(b, ID("two"), FlexWidth(1))
+			}))
+		}))
+		root.Layout()
+		one := root.GetComponentByID("one")
+		two := root.GetComponentByID("two")
+
+		assert.Equal(t, one.GetWidth(), 100)
+		assert.Equal(t, two.GetWidth(), 100)
+	})
 }

--- a/src/display/nano_window.go
+++ b/src/display/nano_window.go
@@ -73,6 +73,7 @@ func (c *NanoWindowComponent) Init() {
 
 	defer c.OnExit()
 	for {
+		// runtime.LockOSThread()
 		if c.ShouldExit() {
 			return
 		}
@@ -82,6 +83,7 @@ func (c *NanoWindowComponent) Init() {
 		c.PollEvents()
 		c.UpdateCursor()
 		c.WaitForFrame(startTime)
+		// runtime.UnlockOSThread()
 	}
 }
 
@@ -92,21 +94,23 @@ func (c *NanoWindowComponent) LayoutDrawAndPaint() {
 	// TODO(lbayes): Only set pixelRatio on init, not every frame
 	pixelRatio := float32(fbWidth) / float32(winWidth)
 
-	c.Width(float64(fbWidth))
-	c.Height(float64(fbHeight))
-
 	if c.ShouldValidate() || fbWidth != c.lastWidth || fbHeight != c.lastHeight {
+		c.Width(float64(fbWidth))
+		c.Height(float64(fbHeight))
+
 		c.lastHeight = fbHeight
 		c.lastWidth = fbWidth
+
+		if c.ShouldValidate() {
+			c.Validate()
+		}
+
 		c.Layout()
 
-		// IF SOMETHING ELSE HAPPENED
+		// TODO(lbayes): We should only CLEAR pixels for rectangles that need to be DRAWN
 		c.LayoutGl()
 		c.ClearGl()
 		c.nanoContext.BeginFrame(int(fbWidth), int(winHeight), pixelRatio)
-
-		c.Validate()
-		c.Layout()
 		c.Draw(c.nanoSurface)
 
 		if false && c.perfGraph != nil {
@@ -115,7 +119,7 @@ func (c *NanoWindowComponent) LayoutDrawAndPaint() {
 		}
 
 		c.nanoContext.EndFrame()
-		c.EnableGlDepthTest()
+		// c.EnableGlDepthTest()
 		c.SwapWindowBuffers()
 	}
 }

--- a/src/display/offset_surface.go
+++ b/src/display/offset_surface.go
@@ -72,9 +72,17 @@ func (s *OffsetSurface) Text(x float64, y float64, text string) {
 
 // NewSurfaceDelegateFor creates a new surface delegate.
 func NewOffsetSurface(d Displayable, delegateTo Surface) Surface {
+	parent := d.GetParent()
+	var x, y float64
+	if parent != nil {
+		x, y = parent.GetXOffset(), parent.GetYOffset()
+	} else {
+		x, y = d.GetXOffset(), d.GetYOffset()
+	}
+
 	return &OffsetSurface{
 		delegateTo: delegateTo,
-		offsetX:    d.GetXOffset(),
-		offsetY:    d.GetYOffset(),
+		offsetX:    x,
+		offsetY:    y,
 	}
 }

--- a/src/display/stack.go
+++ b/src/display/stack.go
@@ -1,6 +1,8 @@
 package display
 
-import "errors"
+import (
+	"errors"
+)
 
 type Stack interface {
 	Push(entry Displayable) error
@@ -50,6 +52,6 @@ func (s *stack) HasNext() bool {
 }
 
 func NewDisplayStack() Stack {
-	entries := make([]Displayable, 0, 10)
+	entries := make([]Displayable, 0, 50)
 	return &stack{entries: entries}
 }

--- a/src/examples/boxes/main.go
+++ b/src/examples/boxes/main.go
@@ -3,16 +3,28 @@ package main
 import (
 	. "display"
 	"runtime"
+	"time"
 )
 
 func init() {
 	runtime.LockOSThread()
 }
 
-var currentMessage = "Msg"
+var messages = []string{"ABCD", "EFGH", "IJKL", "MNOP", "QRST", "UVWX"}
+var currentIndex = 0
+var currentMessage = messages[currentIndex]
+
+func updateMessage(callback func()) {
+	go func() {
+		time.Sleep(time.Second * 1)
+		currentIndex = (currentIndex + 1) % len(messages)
+		currentMessage = messages[currentIndex]
+		callback()
+	}()
+}
 
 func createWindow() (Displayable, error) {
-	return NanoWindow(NewBuilder(), Padding(10), Title("Test Title"), Children(func(b Builder) {
+	return NanoWindow(NewBuilder(), ID("nano-window"), Padding(10), Title("Test Title"), Children(func(b Builder) {
 		Trait(b, "*",
 			BgColor(0xccccccff),
 			FontFace("sans"),
@@ -32,10 +44,15 @@ func createWindow() (Displayable, error) {
 				Text("HELLO WORLD"))
 		}))
 		HBox(b, ID("body"), Padding(5), FlexHeight(3), FlexWidth(1), Children(func() {
-			VBox(b, ID("leftNav"), FlexWidth(1), FlexHeight(1), Padding(10))
+			Box(b, ID("leftNav"), FlexWidth(1), FlexHeight(1), Padding(10))
 			Box(b, ID("content"), FlexWidth(3), FlexHeight(1), Children(func(d Displayable) {
+				updateMessage(func() {
+					d.Invalidate()
+				})
 				Label(b,
-					Width(200),
+					BgColor(0xff0000ff),
+					MinWidth(100),
+					FlexWidth(1),
 					Height(60),
 					FontSize(48),
 					Padding(5),
@@ -51,5 +68,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
 	win.(Window).Init()
 }

--- a/src/examples/boxes/main_test.go
+++ b/src/examples/boxes/main_test.go
@@ -15,8 +15,8 @@ func TestBoxesMain(t *testing.T) {
 		if win == nil {
 			t.Error("Expected win to be returned from createWindow")
 		}
-		if win.GetChildCount() < 2 {
-			t.Errorf("Expected at least 2 children on window, but got %d", win.GetChildCount())
+		if win.GetChildCount() < 1 {
+			t.Errorf("Expected at least 1 child on window, but got %d", win.GetChildCount())
 		}
 		if one == nil {
 			t.Errorf("Expected at least one child")


### PR DESCRIPTION
The root cause was that the invalidated container was creating a new
Builder while the child nodes were referencing the original,
window-scoped builder.

Updated Composable to have a Builder accessor and applied the builder
from ComponentFactory.

Fixed #115 