### PR TITLE
Trying to clean up Validation terminology

### DIFF
--- a/src/display/application_test.go
+++ b/src/display/application_test.go
@@ -19,10 +19,10 @@ func TestApplication(t *testing.T) {
 			one, _ = Box(b, ID("one"))
 		}))
 
-		one.Invalidate()
+		one.InvalidateChildren()
 		nodes := root.InvalidNodes()
 		assert.Equal(t, len(nodes), 1)
-		if !root.ShouldValidate() {
+		if !root.ShouldRecompose() {
 			t.Error("Expected the node to require validation")
 		}
 	})

--- a/src/display/component.go
+++ b/src/display/component.go
@@ -58,12 +58,12 @@ func (c *Component) SetTypeName(name string) {
 	c.Model().TypeName = name
 }
 
-func (c *Component) Invalidate() {
-	c.Root().InvalidateChild(c)
+func (c *Component) InvalidateChildren() {
+	c.InvalidateChildrenFor(c)
 }
 
 // TODO(lbayes): Rename to something less confusing
-func (c *Component) Validate() []Displayable {
+func (c *Component) RecomposeChildren() []Displayable {
 	nodes := c.InvalidNodes()
 	b := c.Builder()
 	for _, node := range nodes {
@@ -77,11 +77,16 @@ func (c *Component) Validate() []Displayable {
 	return nodes
 }
 
-func (c *Component) InvalidateChild(d Displayable) {
+func (c *Component) InvalidateChildrenFor(d Displayable) {
+	// Late binding to find root at the time of invalidation.
+	if c.Parent() != nil {
+		c.Root().InvalidateChildrenFor(d)
+		return
+	}
 	c.dirtyNodes = append(c.dirtyNodes, d)
 }
 
-func (c *Component) ShouldValidate() bool {
+func (c *Component) ShouldRecompose() bool {
 	return len(c.dirtyNodes) > 0
 }
 

--- a/src/display/component_test.go
+++ b/src/display/component_test.go
@@ -452,13 +452,27 @@ func TestBaseComponent(t *testing.T) {
 				}))
 			}))
 
-			three.Invalidate()
-			two.Invalidate()
-			one.Invalidate()
+			three.InvalidateChildren()
+			two.InvalidateChildren()
+			one.InvalidateChildren()
 
 			invalidNodes := root.InvalidNodes()
 			assert.Equal(t, len(invalidNodes), 1)
 			assert.Equal(t, invalidNodes[0].ID(), "one")
+		})
+
+		t.Run("InvalidateChildrenFor always goes to root", func(t *testing.T) {
+			root, _ := Box(NewBuilder(), Children(func(b Builder) {
+				Box(b, Children(func() {
+					Box(b, Children(func() {
+						Box(b, ID("abcd"))
+					}))
+				}))
+			}))
+
+			child := root.FindComponentByID("abcd")
+			child.InvalidateChildrenFor(child.Parent())
+			assert.Equal(t, len(root.InvalidNodes()), 1)
 		})
 
 		t.Run("RemoveAllChildren", func(t *testing.T) {
@@ -486,9 +500,9 @@ func TestBaseComponent(t *testing.T) {
 				two, _ = Box(b, ID("two"))
 			}))
 
-			three.Invalidate()
-			two.Invalidate()
-			one.Invalidate()
+			three.InvalidateChildren()
+			two.InvalidateChildren()
+			one.InvalidateChildren()
 
 			nodes := root.InvalidNodes()
 			assert.Equal(t, len(nodes), 2, "Expected two")
@@ -556,9 +570,9 @@ func TestBaseComponent(t *testing.T) {
 		// Update a derived value
 		textValue = "efgh"
 		// Invalidate a nested child
-		one.Invalidate()
+		one.InvalidateChildren()
 		// Run validation from Root
-		dirtyNodes := root.Validate()
+		dirtyNodes := root.RecomposeChildren()
 
 		if firstInstanceOfTwo == two {
 			t.Error("Expected the inner component to be re-instantiated")

--- a/src/display/interfaces.go
+++ b/src/display/interfaces.go
@@ -127,23 +127,19 @@ type Displayable interface {
 	// Text and Title are both kind of weird for the general
 	// component case... Need to think more about this.
 	Draw(s Surface)
-	Text() string
-	SetText(text string)
-
 	InvalidNodes() []Displayable
-	Title() string
-	SetTitle(title string)
-
-	View() RenderHandler
-	SetView(view RenderHandler)
-
-	Invalidate()
-	InvalidateChild(d Displayable)
-	ShouldValidate() bool
-	Validate() []Displayable
-
+	InvalidateChildren()
+	InvalidateChildrenFor(d Displayable)
 	PushTrait(sel string, opts ...ComponentOption) error
+	RecomposeChildren() []Displayable
+	SetText(text string)
+	SetTitle(title string)
+	SetView(view RenderHandler)
+	ShouldRecompose() bool
+	Text() string
+	Title() string
 	TraitOptions() TraitOptions
+	View() RenderHandler
 }
 
 type Event interface {

--- a/src/display/nano_window.go
+++ b/src/display/nano_window.go
@@ -92,15 +92,15 @@ func (c *NanoWindowComponent) LayoutDrawAndPaint() {
 	// TODO(lbayes): Only set pixelRatio on init, not every frame
 	pixelRatio := float32(fbWidth) / float32(winWidth)
 
-	if c.ShouldValidate() || fbWidth != c.lastWidth || fbHeight != c.lastHeight {
+	if c.ShouldRecompose() || fbWidth != c.lastWidth || fbHeight != c.lastHeight {
 		c.SetWidth(float64(fbWidth))
 		c.SetHeight(float64(fbHeight))
 
 		c.lastHeight = fbHeight
 		c.lastWidth = fbWidth
 
-		if c.ShouldValidate() {
-			c.Validate()
+		if c.ShouldRecompose() {
+			c.RecomposeChildren()
 		}
 
 		c.Layout()

--- a/src/examples/boxes/main.go
+++ b/src/examples/boxes/main.go
@@ -47,7 +47,7 @@ func createWindow() (Displayable, error) {
 			Box(b, ID("leftNav"), FlexWidth(1), FlexHeight(1), Padding(10))
 			Box(b, ID("content"), FlexWidth(3), FlexHeight(1), Children(func(d Displayable) {
 				updateMessage(func() {
-					d.Invalidate()
+					d.InvalidateChildren()
 				})
 				Label(b,
 					BgColor(0xff0000ff),


### PR DESCRIPTION
I really dislike the terms "Validate" and "Invalidate" for marking components that need attention. I feel these terms have meanings associated with form field correctness that will cause confusion in many UI scenarios.

We have additional complexity in that we do not have the ability to mark an individual component as needing to be re-rendered, but we can only mark a component's compose function as needing to be re-run. This is likely going to create needless depth in our trees as people attempt to prematurely (and probably also, appropriately) optimize by isolating change handling.

Anyway, updated the names of some of the worst offenders. More changes likely.

