### PR TITLE
Introduced basic benchmark for component creation, layout and drawing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,16 @@ test-v: $(GOLANG_BINARY) $(GOLANG_TEST_BINARY)
 	@echo "-------------------------------------------------------------------------------"
 	$(GOLANG_TEST_BINARY) test -v ./src/...
 
+# Run all benchmarks
+bench: $(GOLANG_BINARY)
+	$(GOLANG_BINARY) test -bench=. ./src/...
+
 # Run the application binary
 run: $(GOLANG_BINARY)
 	$(GOLANG_BINARY) run ./src/examples/boxes/main.go
 
 # Build a static binary for current platform
-build:
+build: $(GOLANG_BINARY)
 	$(GOLANG_BINARY) build -o out/main-debug src/examples/boxes/main.go
 	$(GOLANG_BINARY) build -ldflags="-s -w" -o out/main src/examples/boxes/main.go
 	ls -la out/

--- a/src/display/component_bench_test.go
+++ b/src/display/component_bench_test.go
@@ -1,0 +1,52 @@
+package display
+
+import (
+	"log"
+	"testing"
+)
+
+func nodeCount(d Displayable) int {
+	count := 0
+	PostOrderVisit(d, func(node Displayable) {
+		count++
+	})
+
+	return count
+}
+
+func BenchmarkComponent(b *testing.B) {
+	var createTree = func(b Builder) (Displayable, error) {
+		return VBox(b, Children(func() {
+			for i := 0; i < 100; i++ {
+				HBox(b, Children(func() {
+					Box(b, Children(func() {
+						Box(b, Children(func() {
+							Box(b, Children(func() {
+								Box(b)
+								Box(b)
+								Box(b)
+								Box(b)
+								Box(b)
+								Box(b)
+							}))
+						}))
+					}))
+				}))
+			}
+		}))
+	}
+
+	b.Run("Basic instantiation", func(b *testing.B) {
+		tree, _ := createTree(NewBuilder())
+		count := nodeCount(tree)
+		log.Printf("BENCHMARK WITH %v NODES", count)
+
+		for i := 0; i < b.N; i++ {
+			builder := NewBuilder()
+			surface := NewFakeSurface()
+			tree, _ := createTree(builder)
+			tree.Layout()
+			tree.Draw(surface)
+		}
+	})
+}

--- a/src/display/fake_surface.go
+++ b/src/display/fake_surface.go
@@ -83,3 +83,7 @@ func (s *FakeSurface) Text(x float64, y float64, text string) {
 func (s *FakeSurface) GetOffsetSurfaceFor(d Displayable) Surface {
 	return s
 }
+
+func NewFakeSurface() *FakeSurface {
+	return &FakeSurface{}
+}

--- a/src/examples/boxes/main.go
+++ b/src/examples/boxes/main.go
@@ -23,6 +23,10 @@ func updateMessage(callback func()) {
 	}()
 }
 
+func getSome() {
+
+}
+
 func createWindow() (Displayable, error) {
 	return NanoWindow(NewBuilder(), ID("nano-window"), Padding(10), Title("Test Title"), Children(func(b Builder) {
 		Trait(b, "*",


### PR DESCRIPTION
Wanted to start building intuitions about where slowness might come from.

Biggest surprise?

The FakeSurface that tracks drawing calls is much slower than I expected.

Early tests showed something like 200,000 ns (millionths of a millisecond!) to create, layout and draw a thousand or so simple/empty HBox/Box nodes.

The split for time taken was:
```
Create          102,000 ns (46.8%)
Layout           35,000 ns (16.1%)
Draw (Fake)  81,000 ns  (37.2%)
```

I haven't taken the time to profile the Draw operation, but a big part of it is definitely the array append work that's being done in the fake surface. Will update later with a BenchSurface that just works to satisfy the interface without introducing any cost.