### PR TITLE
Fixed error returns from Builder

### DIFF
--- a/src/display/builder.go
+++ b/src/display/builder.go
@@ -15,11 +15,16 @@ type Builder interface {
 	Push(d Displayable, options ...ComponentOption)
 	Peek() Displayable
 	Destroy()
+	LastError() error
 }
 
 type builder struct {
 	stack     Stack
 	lastError error
+}
+
+func (b *builder) LastError() error {
+	return b.lastError
 }
 
 func (b *builder) Destroy() {

--- a/src/display/component.go
+++ b/src/display/component.go
@@ -126,6 +126,15 @@ func (c *Component) TraitOptions() TraitOptions {
 }
 
 func (c *Component) Composer(composer interface{}) error {
+	// Ensure we do not already have a compose function assigned
+	if composer != nil &&
+		(c.composeEmpty != nil ||
+			c.composeWithBuilder != nil ||
+			c.composeWithBuilderAndComponent != nil ||
+			c.composeWithComponent != nil) {
+		return errors.New("Components can only accept a single Compose function")
+	}
+
 	switch composer.(type) {
 	case func():
 		c.composeEmpty = composer.(func())

--- a/src/display/component_factory.go
+++ b/src/display/component_factory.go
@@ -100,6 +100,11 @@ func NewComponentFactory(typeName string, c componentConstructor, factoryOpts ..
 		// Send the instance to the provided builder for tree placement.
 		b.Push(instance, options...)
 
+		err := b.LastError()
+		if err != nil {
+			return nil, err
+		}
+
 		// Everything worked great, return the instance.
 		return instance, nil
 	}

--- a/src/display/component_options_test.go
+++ b/src/display/component_options_test.go
@@ -1,0 +1,27 @@
+package display
+
+import (
+	"assert"
+	"testing"
+)
+
+func TestComponentOptions(t *testing.T) {
+	t.Run("Children", func(t *testing.T) {
+
+		t.Run("Simple composer", func(t *testing.T) {
+			box, _ := Box(NewBuilder(), Children(func(b Builder) {
+				Box(b)
+			}))
+
+			assert.Equal(t, box.ChildCount(), 1)
+		})
+
+		t.Run("Accessor fails with second Children application", func(t *testing.T) {
+			box, err := Box(NewBuilder(), Children(func() {}), Children(func() {}))
+
+			assert.Nil(t, box)
+			assert.NotNil(t, err, "Error should be returned")
+			assert.Match(t, "single Compose function", err.Error())
+		})
+	})
+}


### PR DESCRIPTION
Also introduced validation (and error result) when components receive a secondary Children assignment. This should help us avoid inadvertently breaking components that have been defined elsewhere and already compose different children.