### PR TITLE
Cleaned up raw event names

### DIFF
--- a/src/display/component.go
+++ b/src/display/component.go
@@ -561,12 +561,6 @@ func (c *Component) FlexHeight() float64 {
 	return c.Model().FlexHeight
 }
 
-func (c *Component) OnEnterFrame(handler func(d Displayable)) {
-	// NOTE(lbayes): THIS IS NOT HOW THIS SHOULD BE!
-	// Hacking into place in order to get proof of life for animations.
-	log.Println("OnEnterFrame called at:", c.Path())
-}
-
 func (c *Component) SetPadding(value float64) {
 	c.Model().Padding = value
 }

--- a/src/display/component_options.go
+++ b/src/display/component_options.go
@@ -1,5 +1,7 @@
 package display
 
+import "events"
+
 type ComponentOption (func(d Displayable) error)
 
 // ID will set the Component.Id.
@@ -284,9 +286,9 @@ func OnClick(handler EventHandler) ComponentOption {
 	}
 }
 
-func OnEnterFrame(handler DisplayEventHandler) ComponentOption {
+func OnEnterFrame(handler EventHandler) ComponentOption {
 	return func(d Displayable) error {
-		// d.OnFrame(handler)
+		d.On(events.EnterFrame, handler)
 		return nil
 	}
 }

--- a/src/display/emitter.go
+++ b/src/display/emitter.go
@@ -55,7 +55,7 @@ type registeredHandler struct {
 }
 
 type Emitter interface {
-	AddHandler(eventName string, handler EventHandler) Unsubscriber
+	On(eventName string, handler EventHandler) Unsubscriber
 	Bubble(event Event)
 	Emit(event Event)
 	RemoveAllHandlers() bool
@@ -91,7 +91,7 @@ func (e *EmitterBase) Bubble(event Event) {
 	panic("Template method should be overridden")
 }
 
-func (e *EmitterBase) AddHandler(eventName string, handler EventHandler) Unsubscriber {
+func (e *EmitterBase) On(eventName string, handler EventHandler) Unsubscriber {
 	id := newHandlerId()
 	rHandler := &registeredHandler{
 		id:        id,

--- a/src/display/emitter_test.go
+++ b/src/display/emitter_test.go
@@ -17,7 +17,7 @@ func TestDispatcher(t *testing.T) {
 			calledWith = e
 		}
 		instance := NewEmitter()
-		instance.AddHandler("fake-event", handler)
+		instance.On("fake-event", handler)
 		instance.Emit(NewEvent("fake-event", instance, "abcd"))
 		assert.NotNil(t, calledWith, "Expected handler to be called")
 		assert.Equal(t, calledWith.Payload(), "abcd", "Received Payload")
@@ -29,7 +29,7 @@ func TestDispatcher(t *testing.T) {
 			calledWith = e
 		}
 		instance := NewEmitter()
-		remover := instance.AddHandler("fake-event", handler)
+		remover := instance.On("fake-event", handler)
 		remover()
 		instance.Emit(NewEvent("fake-event", nil, nil))
 		assert.Nil(t, calledWith, "Handler was not called")
@@ -41,13 +41,13 @@ func TestDispatcher(t *testing.T) {
 			calledWith = e
 		}
 		instance := NewEmitter()
-		instance.AddHandler("fake-event", handler)
+		instance.On("fake-event", handler)
 		found := instance.RemoveAllHandlers()
 		assert.True(t, found, "Expected to find handlers")
 		instance.Emit(NewEvent("fake-event", nil, nil))
 		assert.Nil(t, calledWith, "Handler was not called")
 
-		instance.AddHandler("fake-event", handler)
+		instance.On("fake-event", handler)
 		instance.Emit(NewEvent("fake-event", nil, nil))
 		assert.NotNil(t, calledWith, "Handler was called")
 	})
@@ -58,8 +58,8 @@ func TestDispatcher(t *testing.T) {
 			calledWith = e
 		}
 		instance := NewEmitter()
-		instance.AddHandler("fake-event-1", handler)
-		instance.AddHandler("fake-event-2", handler)
+		instance.On("fake-event-1", handler)
+		instance.On("fake-event-2", handler)
 		found := instance.RemoveAllHandlersFor("fake-event-2")
 
 		assert.True(t, found, "Expected to find removable handlers")
@@ -100,11 +100,11 @@ func TestDispatcher(t *testing.T) {
 			four, _ = Box(b, ID("four"))
 		}))
 
-		root.AddHandler("fake-event", getHandlerFor(root))
-		one.AddHandler("fake-event", getHandlerFor(one))
-		two.AddHandler("fake-event", getHandlerFor(two))
-		three.AddHandler("fake-event", getHandlerFor(three))
-		four.AddHandler("fake-event", getHandlerFor(four))
+		root.On("fake-event", getHandlerFor(root))
+		one.On("fake-event", getHandlerFor(one))
+		two.On("fake-event", getHandlerFor(two))
+		three.On("fake-event", getHandlerFor(three))
+		four.On("fake-event", getHandlerFor(four))
 
 		three.Bubble(NewEvent("fake-event", three, nil))
 		four.Emit(NewEvent("fake-event", nil, nil))
@@ -122,10 +122,10 @@ func TestDispatcher(t *testing.T) {
 
 		instance := NewEmitter()
 
-		instance.AddHandler("fake-event", func(e Event) {
+		instance.On("fake-event", func(e Event) {
 			e.Cancel()
 		})
-		instance.AddHandler("fake-event", func(e Event) {
+		instance.On("fake-event", func(e Event) {
 			secondCalled = true
 		})
 		instance.Emit(NewEvent("fake-event", nil, nil))

--- a/src/display/fps.go
+++ b/src/display/fps.go
@@ -21,7 +21,7 @@ func FPS(b Builder, instanceOpts ...ComponentOption) (Displayable, error) {
 	avgFps := avgFloats(readings)
 	message := fmt.Sprintf("%v fps", avgFps)
 
-	enterFrameHandler := func(d Displayable) {
+	enterFrameHandler := func(e Event) {
 		fmt.Println("ON ENTER FRAME!")
 	}
 

--- a/src/display/glfw_window.go
+++ b/src/display/glfw_window.go
@@ -8,7 +8,7 @@ import (
 
 type GlfwWindowResizeHandler func(width, height int)
 
-const DefaultFrameRate = 65
+const DefaultFrameRate = 63
 const DefaultWindowWidth = 800
 const DefaultWindowHeight = 600
 const DefaultWindowTitle = "Default Title"

--- a/src/display/interfaces.go
+++ b/src/display/interfaces.go
@@ -58,7 +58,6 @@ type Layoutable interface {
 	MaxWidth() float64
 	MinHeight() float64
 	MinWidth() float64
-	OnEnterFrame(handler func(d Displayable))
 	Padding() float64
 	PaddingBottom() float64
 	PaddingLeft() float64

--- a/src/display/nano_window.go
+++ b/src/display/nano_window.go
@@ -1,6 +1,7 @@
 package display
 
 import (
+	"events"
 	"github.com/shibukawa/nanovgo"
 	"github.com/shibukawa/nanovgo/perfgraph"
 )
@@ -94,7 +95,7 @@ func (c *NanoWindowComponent) LayoutDrawAndPaint() {
 
 	c.nanoContext.BeginFrame(int(fbWidth), int(winHeight), pixelRatio)
 
-	c.Emit(NewEvent("EnterFrame", nil, c))
+	c.Emit(NewEvent(events.EnterFrame, c, nil))
 
 	if c.ShouldRecompose() || fbWidth != c.lastWidth || fbHeight != c.lastHeight {
 		c.SetWidth(float64(fbWidth))

--- a/src/display/transition.go
+++ b/src/display/transition.go
@@ -71,7 +71,7 @@ func Transition(option ComponentOptionAssigner,
 		totalDistance = (finish.(float64) - start.(float64))
 
 		// HACK(lbayes): Should not go to root for this!
-		unsubscriber = d.Root().AddHandler("EnterFrame", func(e Event) {
+		unsubscriber = d.Root().On("EnterFrame", func(e Event) {
 			update(d)
 		})
 

--- a/src/events/events.go
+++ b/src/events/events.go
@@ -1,0 +1,20 @@
+package events
+
+const Clicked = "Clicked"
+const CursorMoved = "CursorMoved"
+const Dragged = "Dragged"
+const EnterFrame = "EnterFrame"
+const KeyDown = "KeyDown"
+const KeyPressed = "KeyPressed"
+const KeyUp = "KeyUp"
+const Pressed = "Pressed"
+const Released = "Released"
+
+const MoveBack = "MoveBack"
+const MoveDown = "MoveDown"
+const MoveForward = "MoveForward"
+const MoveLeft = "MoveLeft"
+const MoveNext = "MoveNext"
+const MovePrevious = "MovePrevious"
+const MoveRight = "MoveRight"
+const MoveUp = "MoveUp"

--- a/src/examples/boxes/main.go
+++ b/src/examples/boxes/main.go
@@ -62,7 +62,7 @@ func createWindow() (Displayable, error) {
 			}))
 		}))
 		HBox(b, ID("footer"), Height(80), FlexWidth(1), Children(func() {
-			FPS(b)
+			// FPS(b)
 		}))
 	}))
 }


### PR DESCRIPTION
Renamed "AddHandler" to "On" because it reads more nicely, especially with event constants.
```
foo.On(EnterFrame, handler)
```
Also added ComponentOption as shortcut to OnEnterFrame, but I'm not sure this is a great idea. Seems tough to keep those in sync with all events. Will probably rework into something more like, `Box(NewBuilder(), On(EnterFrame, handler))`
