### PR TITLE
Integrated a wrapper around external library clock interface

### DIFF
--- a/src/clock/clock.go
+++ b/src/clock/clock.go
@@ -1,0 +1,32 @@
+package clock
+
+import (
+	benclock "github.com/benbjohnson/clock"
+	"time"
+)
+
+// Clock represents an interface to the functions in the standard library time
+// package. Two implementations are available in the clock package. The first
+// is a real-time clock which simply wraps the time package's functions. The
+// second is a mock clock which will only make forward progress when
+// programmatically adjusted.
+type Clock interface {
+	After(d time.Duration) <-chan time.Time
+	AfterFunc(d time.Duration, f func()) *benclock.Timer
+	Now() time.Time
+	Since(t time.Time) time.Duration
+	Sleep(d time.Duration)
+	Tick(d time.Duration) <-chan time.Time
+	Ticker(d time.Duration) *benclock.Ticker
+	Timer(d time.Duration) *benclock.Timer
+}
+
+// New returns an instance of a real-time clock.
+func New() Clock {
+	return benclock.New()
+}
+
+// NewMock returns an instance of the fake clock
+func NewFake() *benclock.Mock {
+	return benclock.NewMock()
+}

--- a/src/display/application.go
+++ b/src/display/application.go
@@ -19,17 +19,14 @@ func (a *ApplicationComponent) FrameRate() int {
 	return a.frameRate
 }
 
-func (a *ApplicationComponent) GetFrameStart() time.Time {
-	return time.Now()
-}
-
 func (a *ApplicationComponent) WaitForFrame(startTime time.Time) {
+	clock := a.Clock()
 	// Wait for whatever amount of time remains between how long we just spent,
 	// and when the next frame (at fps) should be.
-	waitDuration := (time.Second / time.Duration(a.FrameRate())) - time.Since(startTime)
+	waitDuration := (time.Second / time.Duration(a.FrameRate())) - clock.Since(startTime)
 	// NOTE: Looping stops when mouse is pressed on window resizer (on macOS, but not i3wm/Ubuntu Linux)
 	if waitDuration > 0 {
-		time.Sleep(waitDuration)
+		clock.Sleep(waitDuration)
 	} else {
 		log.Println("WARNING: Missed frame budget by %v", waitDuration)
 	}

--- a/src/display/builder.go
+++ b/src/display/builder.go
@@ -1,5 +1,7 @@
 package display
 
+import "github.com/benbjohnson/clock"
+
 // BuilderOption is a configuration option for Builders.
 type BuilderOption func(b Builder) error
 
@@ -11,17 +13,18 @@ type ComponentComposer func(b Builder)
 // syntax to declare component composition.
 // The builder should fall out of scope once the component tree is created.
 type Builder interface {
-	UpdateChildren(d Displayable) error
-	Push(d Displayable, options ...ComponentOption)
-	Peek() Displayable
-	Destroy()
-	LastError() error
-
 	AddTransition(key, handler ComponentOptionAssigner)
+	Clock() clock.Clock
+	Destroy()
 	GetTransition(key string) ComponentOption
+	LastError() error
+	Peek() Displayable
+	Push(d Displayable, options ...ComponentOption)
+	UpdateChildren(d Displayable) error
 }
 
 type builder struct {
+	clock     clock.Clock
 	stack     Stack
 	lastError error
 }
@@ -31,6 +34,10 @@ func (b *builder) AddTransition(key, handler ComponentOptionAssigner) {
 
 func (b *builder) GetTransition(key string) ComponentOption {
 	return nil
+}
+
+func (b *builder) Clock() clock.Clock {
+	return b.clock
 }
 
 func (b *builder) LastError() error {
@@ -122,6 +129,12 @@ func (b *builder) Push(d Displayable, options ...ComponentOption) {
 }
 
 // NewBuilder returns a clean builder instance.
-func NewBuilder() Builder {
-	return &builder{}
+func NewBuilder() *builder {
+	return &builder{clock: clock.New()}
+}
+
+// NewBuilderWith using the provided clock instead of the real one.
+// Should only be used for testing.
+func NewBuilderUsing(clock clock.Clock) *builder {
+	return &builder{clock: clock}
 }

--- a/src/display/component.go
+++ b/src/display/component.go
@@ -1,6 +1,7 @@
 package display
 
 import (
+	"clock"
 	"errors"
 	"github.com/rs/xid"
 	"log"
@@ -647,6 +648,10 @@ func (c *Component) Builder() Builder {
 		return c.parent.Builder()
 	}
 	return c.builder
+}
+
+func (c *Component) Clock() clock.Clock {
+	return c.Builder().Clock()
 }
 
 func (c *Component) ChildCount() int {

--- a/src/display/nano_window.go
+++ b/src/display/nano_window.go
@@ -78,7 +78,7 @@ func (c *NanoWindowComponent) Init() {
 			return
 		}
 
-		startTime := c.GetFrameStart()
+		startTime := c.Clock().Now()
 		c.LayoutDrawAndPaint()
 		c.PollEvents()
 		c.UpdateCursor()

--- a/src/display/transition.go
+++ b/src/display/transition.go
@@ -28,11 +28,13 @@ func transitionToKey(
 
 // Transition is a helper that allows us to define and name Transitions in order
 // to later apply them as Traits.
-func Transition(option ComponentOptionAssigner,
+func Transition(b Builder, option ComponentOptionAssigner,
 	start interface{},
 	finish interface{},
 	durationMs int,
 	easingFunc EasingFunc) ComponentOption {
+
+	clock := b.Clock()
 
 	// key := transitionToKey(option, start, finish, durationMs, easingFunc)
 	optionValue := reflect.ValueOf(option)
@@ -42,7 +44,7 @@ func Transition(option ComponentOptionAssigner,
 	var unsubscriber Unsubscriber
 
 	var update = func(d Displayable) {
-		elapsedTimeMs := time.Since(startTime).Nanoseconds() / int64(time.Millisecond)
+		elapsedTimeMs := clock.Since(startTime).Nanoseconds() / int64(time.Millisecond)
 
 		var percentComplete float32
 
@@ -67,7 +69,7 @@ func Transition(option ComponentOptionAssigner,
 	}
 
 	var listen = func(d Displayable) {
-		startTime = time.Now()
+		startTime = clock.Now()
 		totalDistance = (finish.(float64) - start.(float64))
 
 		// HACK(lbayes): Should not go to root for this!

--- a/src/display/transition_test.go
+++ b/src/display/transition_test.go
@@ -2,26 +2,35 @@ package display
 
 import (
 	"assert"
+	"clock"
 	"github.com/fogleman/ease"
 	"testing"
+	"time"
 )
 
 func TestTransition(t *testing.T) {
 
 	t.Run("Instantiable", func(t *testing.T) {
+		fakeClock := clock.NewFake()
 		var tweenX ComponentOption
-		root, _ := Box(NewBuilder(), Children(func(b Builder) {
-			tweenX = Transition(X,
+		root, _ := Box(NewBuilderUsing(fakeClock), Children(func(b Builder) {
+			tweenX = Transition(b,
+				X,
 				110.0,
 				200.0,
 				200,
 				ease.OutCubic)
-			Box(b, tweenX)
-
+			Box(b, tweenX, ExcludeFromLayout(true))
 		}))
 
 		child := root.ChildAt(0)
 		assert.NotNil(t, tweenX, "Expected tween creation")
+
+		root.Layout()
 		assert.Equal(t, int(child.X()), 110)
+		// I expect enter frames to fire when this happens!
+		// But they don't because they're currently implemented by the NanoWindow
+		fakeClock.Add(100 * time.Millisecond)
+		// assert.Equal(t, int(child.X()), 120)
 	})
 }

--- a/src/examples/anim/main.go
+++ b/src/examples/anim/main.go
@@ -14,29 +14,29 @@ func init() {
 
 func createWindow() (Displayable, error) {
 
-	// var currentMove ComponentOption
-	// moveLeft := Transition(X, 700.0, 0.0, 2000, ease.InOutCubic)
-	moveRight := Transition(X, 0.0, 700.0, 2000, ease.InOutCubic)
-
-	/*
-		var currentMoveName string
-			var toggleCurrentMove = func(e Event) {
-				if currentMoveName == "moveLeft" {
-					currentMove = moveRight
-					currentMoveName = "moveRight"
-				} else {
-					currentMove = moveLeft
-					currentMoveName = "moveLeft"
-				}
-			}
-	*/
-
 	return NanoWindow(
 		NewBuilder(),
 		ID("nano-window"),
 		Width(800),
 		Height(600),
 		Children(func(b Builder) {
+			// var currentMove ComponentOption
+			// moveLeft := Transition(X, 700.0, 0.0, 2000, ease.InOutCubic)
+			moveRight := Transition(b, X, 0.0, 700.0, 2000, ease.InOutCubic)
+
+			/*
+				var currentMoveName string
+					var toggleCurrentMove = func(e Event) {
+						if currentMoveName == "moveLeft" {
+							currentMove = moveRight
+							currentMoveName = "moveRight"
+						} else {
+							currentMove = moveLeft
+							currentMoveName = "moveLeft"
+						}
+					}
+			*/
+
 			Box(b,
 				ID("moving-box"),
 				ExcludeFromLayout(true),

--- a/src/examples/boxes/main.go
+++ b/src/examples/boxes/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"clock"
 	. "display"
 	"runtime"
 	"time"
@@ -16,9 +17,9 @@ var messages = []string{"ABCD", "EFGH", "IJKL", "MNOP", "QRST", "UVWX"}
 var currentIndex = 0
 var currentMessage = messages[currentIndex]
 
-func updateMessage(callback func()) {
+func updateMessage(clock clock.Clock, callback func()) {
 	go func() {
-		time.Sleep(time.Second * 1)
+		clock.Sleep(time.Second * 1)
 		currentIndex = (currentIndex + 1) % len(messages)
 		currentMessage = messages[currentIndex]
 		callback()
@@ -48,7 +49,7 @@ func createWindow() (Displayable, error) {
 		HBox(b, ID("body"), Padding(5), FlexHeight(3), FlexWidth(1), Children(func() {
 			Box(b, ID("leftNav"), FlexWidth(1), FlexHeight(1), Padding(10))
 			Box(b, ID("content"), FlexWidth(3), FlexHeight(1), Children(func(d Displayable) {
-				updateMessage(func() {
+				updateMessage(b.Clock(), func() {
 					d.InvalidateChildren()
 				})
 				Label(b,


### PR DESCRIPTION
Tried to advance time from a test, but failed because the Builder does not manage enter frame events and that's what the Transition uses. Backing up and going to rethink where enter frame events come
from.